### PR TITLE
uptake jakarta dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ wsit/ws-sx/wssx-impl/golden.mh
 wsit/ws-sx/wssx-impl/golden.msg
 wsit/ws-sx/wssx-impl/recvd.mh
 wsit/ws-sx/wssx-impl/recvd.msg
-dependency-reduced-pom.xml

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 
-    Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions

--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -18,7 +18,7 @@
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-bom</artifactId>
         <relativePath>../bom/pom.xml</relativePath>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.metro</groupId>
@@ -28,13 +28,14 @@
     <description>Metro Web Services Stack Dependency POM for Metro-CS</description>
 
     <properties>
-        <connector-api.version>1.5</connector-api.version>
-        <transaction-api.version>1.3</transaction-api.version>
-        <glassfish.version>4.1.2</glassfish.version>
-        <grizzly.version>1.9.36</grizzly.version>
-        <gmbal.version>4.0.0-b002</gmbal.version>
+        <connector-api.version>1.7.2</connector-api.version>
+        <transaction-api.version>1.3.1</transaction-api.version>
+        <glassfish.version>5.1.0</glassfish.version>
         <jaxws.home.uri>http://javaee.github.io/metro-jax-ws</jaxws.home.uri>
-        <santuario.version>2.1.2</santuario.version>
+        <santuario.version>1.5.8</santuario.version>
+        <commons-logging.version>1.1.2</commons-logging.version>
+        <xmlrpc-api.version>1.1.3</xmlrpc-api.version>
+        <xmlrpc-impl.version>1.1.5</xmlrpc-impl.version>
     </properties>
 
     <dependencyManagement>
@@ -51,14 +52,14 @@
 
             <!-- Should this really be reexported? -->
             <dependency>
-                <groupId>javax.resource</groupId>
-                <artifactId>connector-api</artifactId>
+                <groupId>jakarta.resource</groupId>
+                <artifactId>jakarta.resource-api</artifactId>
                 <version>${connector-api.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>javax.transaction</groupId>
-                <artifactId>javax.transaction-api</artifactId>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
                 <version>${transaction-api.version}</version>
             </dependency>
 

--- a/wsit/boms/bom-gf/pom.xml
+++ b/wsit/boms/bom-gf/pom.xml
@@ -18,7 +18,7 @@
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-bom</artifactId>
         <relativePath>../bom/pom.xml</relativePath>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.metro</groupId>

--- a/wsit/boms/bom/pom.xml
+++ b/wsit/boms/bom/pom.xml
@@ -17,16 +17,16 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.5</version>
     </parent>
 
     <groupId>org.glassfish.metro</groupId>
     <artifactId>metro-bom</artifactId>
     <packaging>pom</packaging>
     <name>Metro Web Services Stack Dependency POM</name>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.3-SNAPSHOT</version>
     <description>Metro Web Services Stack Dependency POM</description>
-    
+
     <url>http://javaee.github.io/metro</url>
 
     <licenses>
@@ -56,10 +56,10 @@
     </developers>
 
     <properties>
-        <jaxws.ri.version>2.3.1</jaxws.ri.version>
-        <jaxws.maven.plugin.version>2.3.1</jaxws.maven.plugin.version>
+        <jaxws.ri.version>2.3.2</jaxws.ri.version>
+        <jaxws.maven.plugin.version>2.3.2</jaxws.maven.plugin.version>
     </properties>
-        
+
     <dependencyManagement>
         <dependencies>
 
@@ -101,7 +101,7 @@
                 <type>war</type>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>metro-cm-api</artifactId>
@@ -151,13 +151,13 @@
                 <artifactId>wsrm-impl</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>ws-mex</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>metro-runtime-api</artifactId>
@@ -174,18 +174,18 @@
                 <artifactId>metro-commons</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>soaptcp-api</artifactId>
                 <version>${project.version}</version>
-            </dependency>            
+            </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>soaptcp-impl</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>wssx-api</artifactId>
@@ -196,7 +196,7 @@
                 <artifactId>wssx-impl</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>xmlfilter</artifactId>
@@ -239,7 +239,7 @@
                 <artifactId>webservices-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            
+
             <!-- GF -->
             <dependency>
                 <groupId>${project.groupId}</groupId>
@@ -290,11 +290,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.0.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/wsit/bundles/metro-standalone/pom.xml
+++ b/wsit/bundles/metro-standalone/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-standalone</artifactId>
@@ -68,7 +68,7 @@
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>maven-replacer-plugin</artifactId>
-                <executions>                
+                <executions>
                     <execution>
                         <id>replace-jaxws-with-metro</id>
                         <phase>prepare-package</phase>
@@ -119,7 +119,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
@@ -173,7 +173,7 @@
                     <plugin>
                         <groupId>com.google.code.maven-replacer-plugin</groupId>
                         <artifactId>maven-replacer-plugin</artifactId>
-                        <executions>                
+                        <executions>
                             <execution>
                                 <id>replace-jaxws-with-metro</id>
                                 <phase>prepare-package</phase>
@@ -225,7 +225,7 @@
                             </execution>
                         </executions>
                     </plugin>
-            
+
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
                         <configuration>
@@ -327,16 +327,15 @@
             <artifactId>webservices-tools</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- wstx-services was removed from the project. -->
-        <!--dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wstx-services</artifactId>
             <type>war</type>
             <version>${project.version}</version>
-        </dependency-->
+        </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
@@ -374,22 +373,17 @@
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-ri</artifactId>
             <type>zip</type>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-eclipselink-plugin</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
-            <version>2.7.3</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>sdo-eclipselink-plugin</artifactId>
         </dependency>
         <dependency>
-            <groupId>commonj.sdo</groupId>
+            <groupId>org.eclipse.persistence</groupId>
             <artifactId>commonj.sdo</artifactId>
         </dependency>
         <dependency>
@@ -399,7 +393,6 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
         </dependency>
     </dependencies>
 
@@ -410,7 +403,7 @@
         <java.version.string>java.version</java.version.string>
         <as.home.env.string>env.AS_HOME</as.home.env.string>
         <catalina.home.env.string>env.CATALINA_HOME</catalina.home.env.string>
-        
+
         <product.name>Metro ${project.version}</product.name>
         <release.date>${maven.build.timestamp}</release.date>
         <bundle.artifact.name>${project.artifactId}-${project.version}.zip</bundle.artifact.name>

--- a/wsit/bundles/metro-standalone/src/main/assembly/assembly-otn.xml
+++ b/wsit/bundles/metro-standalone/src/main/assembly/assembly-otn.xml
@@ -76,15 +76,13 @@
             <outputDirectory>metro/osgi</outputDirectory>
 
             <includes>
-                <include>javax.xml.bind:jaxb-api</include>
+                <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
                 <include>com.sun.xml.bind:jaxb-osgi</include>
                 <include>${project.groupId}:webservices-api-osgi</include>
                 <include>${project.groupId}:webservices-extra-jdk-packages</include>
                 <include>${project.groupId}:webservices-osgi</include>
                 <include>com.fasterxml.woodstox:woodstox-core</include>
                 <include>org.codehaus.woodstox:stax2-api</include>
-                <include>org.apache.santuario:xmlsec</include>
-                <include>commons-logging:commons-logging</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/wsit/bundles/metro-standalone/src/main/assembly/assembly.xml
+++ b/wsit/bundles/metro-standalone/src/main/assembly/assembly.xml
@@ -75,15 +75,13 @@
             <directoryMode>0755</directoryMode>
 
             <includes>
-                <include>javax.xml.bind:jaxb-api</include>
+                <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
                 <include>com.sun.xml.bind:jaxb-osgi</include>
                 <include>${project.groupId}:webservices-api-osgi</include>
                 <include>${project.groupId}:webservices-extra-jdk-packages</include>
                 <include>${project.groupId}:webservices-osgi</include>
                 <include>com.fasterxml.woodstox:woodstox-core</include>
                 <include>org.codehaus.woodstox:stax2-api</include>
-                <include>org.apache.santuario:xmlsec</include>
-                <include>commons-logging:commons-logging</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/wsit/bundles/pom.xml
+++ b/wsit/bundles/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>bundles</artifactId>
@@ -45,29 +45,4 @@
         <module>metro-standalone</module>
     </modules>
 
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <sourcepath>${generated.sources.dir}</sourcepath>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/wsit/bundles/webservices-api-osgi/pom.xml
+++ b/wsit/bundles/webservices-api-osgi/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>webservices-api-osgi</artifactId>
@@ -90,7 +90,7 @@
                         <goals>
                             <goal>enforce</goal>
                         </goals>
-                        <phase>validate</phase>
+                        <phase>initialize</phase>
                         <configuration>
                             <rules>
                                 <requireProperty>
@@ -110,11 +110,10 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>        
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
                 <executions>
                     <execution>
                         <id>bundle-manifest</id>
@@ -131,6 +130,7 @@
                                     javax.xml.soap.*;version=${saaj-api.osgiVersion}
                                 </Export-Package>
                                 <Import-Package>
+                                    javax.activation;version=!;resolution:=optional,
                                     javax.xml.bind;version=${jaxb-api.osgiVersion},
                                     javax.xml.bind.*;version=${jaxb-api.osgiVersion},
                                     *
@@ -174,29 +174,6 @@
             </plugin>
         </plugins>
     </build>
-    
-   <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                  <plugin>
-                     <groupId>org.apache.maven.plugins</groupId>
-                     <artifactId>maven-javadoc-plugin</artifactId>
-                     <configuration>
-                        <additionalJOptions>
-                          <additionalJOption>--add-modules</additionalJOption>
-                          <additionalJOption>java.activation</additionalJOption>
-                        </additionalJOptions>
-                    </configuration>
-                   </plugin>
-                </plugins>
-            </build>
-        </profile>
-   </profiles>
 
     <dependencies>
         <dependency>
@@ -204,10 +181,6 @@
             <artifactId>webservices-api</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>
-        </dependency>
-       <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>     
         </dependency>
     </dependencies>
 

--- a/wsit/bundles/webservices-api/pom.xml
+++ b/wsit/bundles/webservices-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>webservices-api</artifactId>
@@ -40,39 +40,39 @@
                             <goal>unpack</goal>
                         </goals>
                         <configuration>
-                           <excludes>module-info*,javax/transaction/xa/*</excludes>
+                            <excludes>module-info*,pom.xml</excludes>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>javax.jws</groupId>
-                                    <artifactId>javax.jws-api</artifactId>
+                                    <groupId>jakarta.jws</groupId>
+                                    <artifactId>jakarta.jws-api</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>javax.xml.soap</groupId>
-                                    <artifactId>javax.xml.soap-api</artifactId>
+                                    <groupId>jakarta.xml.soap</groupId>
+                                    <artifactId>jakarta.xml.soap-api</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>javax.xml.bind</groupId>
-                                    <artifactId>jaxb-api</artifactId>
+                                    <groupId>jakarta.xml.bind</groupId>
+                                    <artifactId>jakarta.xml.bind-api</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>javax.xml.ws</groupId>
-                                    <artifactId>jaxws-api</artifactId>
+                                    <groupId>jakarta.xml.ws</groupId>
+                                    <artifactId>jakarta.xml.ws-api</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>javax.transaction</groupId>
-                                    <artifactId>javax.transaction-api</artifactId>
+                                    <groupId>jakarta.transaction</groupId>
+                                    <artifactId>jakarta.transaction-api</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
@@ -119,69 +119,73 @@
                             </filters>
                             <artifactSet>
                                 <includes>
-                                    <include>javax.xml.ws:jaxws-api</include>
-                                    <include>javax.xml.bind:jaxb-api</include>
-                                    <include>javax.xml.soap:javax.xml.soap-api</include>
-                                    <include>javax.jws:javax.jws-api</include>
-                                    <include>javax.transaction:javax.transaction-api</include>
+                                    <include>jakarta.xml.ws:jakarta.xml.ws-api</include>
+                                    <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
+                                    <include>jakarta.xml.soap:jakarta.xml.soap-api</include>
+                                    <include>jakarta.jws:jakarta.jws-api</include>
+                                    <include>jakarta.transaction:jakarta.transaction-api</include>
                                 </includes>
                             </artifactSet>
                             <createSourcesJar>false</createSourcesJar>
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
                             </transformers>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalDependencies>
+                        <dependency>
+                            <groupId>javax.enterprise</groupId>
+                            <artifactId>cdi-api</artifactId>
+                            <version>2.0.SP1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>jakarta.interceptor</groupId>
+                            <artifactId>jakarta.interceptor-api</artifactId>
+                            <version>1.2.3</version>
+                        </dependency>
+                    </additionalDependencies>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>META-INF/**</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-              <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <additionalJOptions>
-                            <additionalJOption>--add-modules</additionalJOption>
-                            <additionalJOption>java.activation,java.xml.ws.annotation</additionalJOption>
-                        </additionalJOptions>
-                    </configuration>
-                </plugin>
-              </plugins>
-             </build>
-        </profile>
-    </profiles>
 
     <dependencies>
         <!-- Shaded dependencies -->
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.jws</groupId>
-            <artifactId>javax.jws-api</artifactId>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
     </dependencies>
     <properties>

--- a/wsit/bundles/webservices-extra-api/pom.xml
+++ b/wsit/bundles/webservices-extra-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>webservices-extra-api</artifactId>
@@ -42,15 +42,15 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>javax.xml.registry</groupId>
-                                    <artifactId>javax.xml.registry-api</artifactId>
+                                    <groupId>jakarta.xml.registry</groupId>
+                                    <artifactId>jakarta.xml.registry-api</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>javax.xml.rpc</groupId>
-                                    <artifactId>javax.xml.rpc-api</artifactId>
+                                    <groupId>jakarta.xml.rpc</groupId>
+                                    <artifactId>jakarta.xml.rpc-api</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
@@ -89,11 +89,12 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <include>javax.xml.rpc:javax.xml.rpc-api</include>
-                                    <include>javax.xml.registry:javax.xml.registry-api</include>
+                                    <include>jakarta.xml.rpc:jakarta.xml.rpc-api</include>
+                                    <include>jakarta.xml.registry:jakarta.xml.registry-api</include>
                                 </includes>
                             </artifactSet>
                             <createSourcesJar>false</createSourcesJar>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
@@ -104,47 +105,24 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-              <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <additionalJOptions>
-                            <additionalJOption>--add-modules</additionalJOption>
-                            <additionalJOption>java.activation</additionalJOption>
-                        </additionalJOptions>
-                    </configuration>
-                </plugin>
-              </plugins>
-             </build>
-        </profile>
-    </profiles>
-
     <dependencies>
         <!-- Shaded dependencies -->
         <dependency>
-            <groupId>javax.xml.rpc</groupId>
-            <artifactId>javax.xml.rpc-api</artifactId>
+            <groupId>jakarta.xml.rpc</groupId>
+            <artifactId>jakarta.xml.rpc-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.registry</groupId>
-            <artifactId>javax.xml.registry-api</artifactId>
+            <groupId>jakarta.xml.registry</groupId>
+            <artifactId>jakarta.xml.registry-api</artifactId>
         </dependency>
          <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
          <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>     
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
 
         <!-- Non shaded dependencies -->

--- a/wsit/bundles/webservices-extra-jdk-packages/pom.xml
+++ b/wsit/bundles/webservices-extra-jdk-packages/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>webservices-extra-jdk-packages</artifactId>

--- a/wsit/bundles/webservices-extra/pom.xml
+++ b/wsit/bundles/webservices-extra/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>webservices-extra</artifactId>
@@ -50,20 +50,28 @@
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>javax.security.auth.message</groupId>
-                                    <artifactId>javax.security.auth.message-api</artifactId>
+                                    <groupId>jakarta.security.auth.message</groupId>
+                                    <artifactId>jakarta.security.auth.message-api</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>javax.mail</groupId>
-                                    <artifactId>mail</artifactId>
+                                    <groupId>jakarta.annotation</groupId>
+                                    <artifactId>jakarta.annotation-api</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.mail</groupId>
+                                    <artifactId>jakarta.mail</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
+                            <excludes>META-INF/gfprobe-provider.xml,com/sun/grizzly/**,com/sun/org/**,org/**</excludes>
                         </configuration>
                     </execution>
                 </executions>
@@ -98,9 +106,9 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.sun.grizzly:grizzly-framework-http</include>
-                                    <include>javax.security.auth.message:javax.security.auth.message-api</include>
-                                    <include>javax.annotation:javax.annotation-api</include>
-                                    <include>javax.mail:mail</include>
+                                    <include>jakarta.security.auth.message:jakarta.security.auth.message-api</include>
+                                    <include>jakarta.annotation:jakarta.annotation-api</include>
+                                    <include>com.sun.mail:jakarta.mail</include>
                                 </includes>
                             </artifactSet>
                             <filters>
@@ -116,6 +124,7 @@
                             </filters>
                             <createSourcesJar>false</createSourcesJar>
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
@@ -133,54 +142,27 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-              <plugins>
-                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <additionalJOptions>
-                            <additionalJOption>--add-modules</additionalJOption>
-                            <additionalJOption>java.activation</additionalJOption>
-                        </additionalJOptions>
-                    </configuration>
-                </plugin>
-              </plugins>
-             </build>
-        </profile>
-    </profiles>
-
     <dependencies>
         <dependency>
             <groupId>com.sun.grizzly</groupId>
             <artifactId>grizzly-framework-http</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.security.auth.message</groupId>
-            <artifactId>javax.security.auth.message-api</artifactId>
+            <groupId>jakarta.security.auth.message</groupId>
+            <artifactId>jakarta.security.auth.message-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-         <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
         </dependency>
     </dependencies>
     <properties>

--- a/wsit/bundles/webservices-osgi-aix/pom.xml
+++ b/wsit/bundles/webservices-osgi-aix/pom.xml
@@ -17,38 +17,31 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>webservices-osgi-aix</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>Metro Web Services Runtime OSGi Bundle for AIX</name>
     <description>Metro Web Services Runtime OSGi Bundle for AIX</description>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <excludePackageNames>*.msv.*:xsdlib.*:*com.sun.xml.ws*:com.sun.tools.*:com.sun.enterprise.*:java.*:isorelax.*:src.*:*javanet*:*test*:*ctc*:*glassfish*:*com.sun.istack.tools*:javax.xml.crypto.*:org.apache.xml.security.*:org.apache.jcp.xml.dsig.internal.*:org.apache.commons.*:com.sun.grizzly.*</excludePackageNames>
-                </configuration>
-            </plugin>
             <plugin> <!-- want to unpack sources from individual modules -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>attach-meta-inf-entries</id>
-                        <phase>process-sources</phase>
+                        <id>unpack-meta-inf-entries</id>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
                             <excludeTransitive>true</excludeTransitive>
                             <includes>META-INF/services/*, META-INF/metro-default.xml, META-INF/jaxrpc/*</includes>
-                            <excludes>META-INF/services/com.sun.xml.ws.spi.db.*, META-INF/services/com.sun.tools.*, META-INF/services/javax.xml.bind.*, META-INF/services/javax.xml.stream.*, META-INF/services/org.*</excludes>
-                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                            <excludes>META-INF/services/com.sun.xml.ws.spi.db.*, META-INF/services/com.sun.tools.*, META-INF/services/javax.xml.bind.*, META-INF/services/javax.xml.stream.*, META-INF/services/javax.mail.*, META-INF/services/org.*</excludes>
+                            <outputDirectory>${project.build.directory}/generated-sources/resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
@@ -60,8 +53,8 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>javax.xml.registry</groupId>
-                                    <artifactId>javax.xml.registry-api</artifactId>
+                                    <groupId>jakarta.xml.registry</groupId>
+                                    <artifactId>jakarta.xml.registry-api</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
@@ -97,6 +90,20 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>add-meta-inf-entries</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/generated-sources/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>add-source</goal>
@@ -118,7 +125,7 @@
                         <goals>
                             <goal>enforce</goal>
                         </goals>
-                        <phase>validate</phase>
+                        <phase>initialize</phase>
                         <configuration>
                             <rules>
                                 <requireProperty>
@@ -132,6 +139,14 @@
                                 <requireProperty>
                                     <property>saaj-api.osgiVersion</property>
                                     <message>Property saaj-api.osgiVersion not imported or set!</message>
+                                </requireProperty>
+                                <requireProperty>
+                                    <property>saaj-impl.osgiVersion</property>
+                                    <message>Property saaj-impl.osgiVersion not imported or set!</message>
+                                </requireProperty>
+                                <requireProperty>
+                                    <property>jaxrpc-impl.osgiVersion</property>
+                                    <message>Property jaxrpc-impl.osgiVersion not imported or set!</message>
                                 </requireProperty>
                                 <requireProperty>
                                     <property>jaxws.osgiVersion</property>
@@ -155,180 +170,149 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <id>osgi-bundle</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>bundle</goal>
-                        </goals>
-                        <configuration>
-                            <excludeDependencies>jaxws-eclipselink-plugin,sdo-eclipselink-plugin</excludeDependencies>
-                            <instructions>
-                                <Export-Package>
-                                    com.oracle.webservices.*;version=${jaxws.osgiVersion},
-                                    com.oracle.xmlns.webservices.jaxws_databinding;version=${jaxws.osgiVersion},
-                                    com.sun.istack.ws.*;version=${jaxb.osgiVersion},
-                                    com.sun.istack.localization;version=${jaxb.osgiVersion};uses:="com.sun.xml.ws.resources,com.sun.tools.ws.resources",
-                                    com.sun.tools.ws.*;version=${jaxws.osgiVersion},
-                                    com.sun.wsit.security.*;version=${metro.osgiVersion},
-                                    com.sun.xml.messaging.saaj.*;version=1.4,
-                                    com.sun.xml.registry.*;version=1.0,
-                                    com.sun.xml.rpc.plugins;version=${metro.osgiVersion},
-                                    com.sun.xml.rpc.security;version=${metro.osgiVersion},
-                                    com.sun.xml.rpc.*;version=1.1.2,
-                                    com.sun.xml.security.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.api.config.management;version=${jaxws.osgiVersion},
-                                    com.sun.xml.ws.api.config.management.policy;version=${jaxws.osgiVersion},
-                                    com.sun.xml.ws.api.config.management.jmx;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.api.security.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.api.transport.tcp.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.api.tx.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.assembler.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.commons.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.config.management.policy.*;version=${jaxws.osgiVersion},
-                                    com.sun.xml.ws.config.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.metro.api.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.policy.config.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.policy.impl.bindings.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.policy.jaxws.*;version=${jaxws.osgiVersion},
-                                    com.sun.xml.ws.policy.jcaps.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.policy.localization.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.policy.parser.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.runtime.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.rx.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.security.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.transport.tcp.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.*;version=${jaxws.osgiVersion},
-                                    com.sun.xml.wss.*;version=${metro.osgiVersion},
-                                    org.jvnet.ws.databinding.*;version=${jaxws.osgiVersion},
-                                    org.jvnet.ws.message.*;version=${jaxws.osgiVersion},
-                                    org.jvnet.ws.*;version=${jaxws.osgiVersion},
-                                    org.apache.jcp.xml.dsig.*;version=${santuario.version},
-                                    org.apache.xml.security;version=${santuario.version},
-                                    org.apache.xml.security.*;version=${santuario.version}
-                                </Export-Package>
-                                <Import-Package>
-                                    com.ibm.security.util;resolution:=optional,
-                                    com.ibm.security.x509;resolution:=optional,
-                                    com.sun.istack.*;version=${jaxb.osgiVersion},
-                                    com.sun.security.auth.callback;resolution:=optional,
-                                    sun.security.action;resolution:=optional,
-                                    sun.security.jgss;resolution:=optional,
-                                    sun.security.jgss.spi;resolution:=optional,
-                                    sun.security.krb5;resolution:=optional,
-                                    sun.security.krb5.internal.crypto;resolution:=optional,
-                                    sun.security.util;resolution:=optional,
-                                    sun.security.x509;resolution:=optional,
-                                    com.sun.security.jgss;resolution:=optional,
-                                    com.sun.appserv.server;resolution:=optional,
-                                    com.sun.enterprise.security.*;resolution:=optional,
-                                    com.sun.enterprise.transaction.*;resolution:=optional,
-                                    com.sun.enterprise.web.*;resolution:=optional,
-                                    org.glassfish.webservice;resolution:=optional,
-                                    org.glassfish.webservice.monitoring;resolution:=optional,
-                                    com.sun.mail.util;resolution:=optional,
-                                    com.sun.msv.*;resolution:=optional,
-                                    com.sun.org.apache.xalan.internal.*;resolution:=optional,
-                                    com.sun.org.apache.xml.internal.*;resolution:=optional,
-                                    com.sun.org.apache.xerces.internal.*;resolution:=optional,
-                                    com.sun.xml.bind.api.impl;resolution:=optional,
-                                    com.sun.xml.bind.serializer;resolution:=optional,
-                                    com.sun.xml.bind.validator;resolution:=optional,
-                                    com.sun.xml.rpc.*;resolution:=optional,
-                                    com.sun.xml.ws.spi.runtime;resolution:=optional,
-                                    com.sun.xml.util;resolution:=optional,
-                                    javax.ejb;resolution:=optional;version=3.0,
-                                    javax.jws;version=2.0,
-                                    javax.jws.soap;version=2.0,
-                                    javax.xml.soap.*;version=${saaj-api.osgiVersion},
-                                    javax.xml.ws.*;version=${jaxws-api.osgiVersion},
-                                    javax.xml.bind.*;version=${jaxb-api.osgiVersion},
-                                    org.apache.coyote;resolution:=optional,
-                                    javax.xml.crypto.*;resolution:=optional;version=0,
-                                    org.apache.tomcat.util.buf;resolution:=optional,
-                                    org.iso_relax.verifier.impl;resolution:=optional,
-                                    org.jvnet.mimepull;resolution:=optional,
-                                    org.relaxng.datatype;resolution:=optional,
-                                    org.relaxng.datatype.helpers;resolution:=optional,
-                                    org.apache.xml.dtm;resolution:=optional,
-                                    org.apache.xml.utils;resolution:=optional,
-                                    org.apache.xpath;resolution:=optional,
-                                    org.apache.xpath.compiler;resolution:=optional,
-                                    org.apache.xpath.functions;resolution:=optional,
-                                    org.apache.xpath.objects;resolution:=optional,
-                                    org.w3c.dom;resolution:=optional,
-                                    org.xml.sax;resolution:=optional,
-                                    org.apache.log;resolution:=optional,
-                                    org.apache.log4j;resolution:=optional,
-                                    org.apache.avalon.framework.logger;resolution:=optional,
-                                    *
-                                </Import-Package>
-                                <Private-Package>
-                                    com.sun.xml.stream.*,
-                                    com.sun.xml.xwss.*;version=${metro.osgiVersion},
-                                    com.sun.xml.util.*;version=${metro.osgiVersion};include="XMLCipherAdapter",
-                                    javanet.staxutils.*,
-                                    org.apache.commons.logging,
-                                    org.apache.commons.logging.impl,
-                                </Private-Package>
-                                <DynamicImport-Package>
-                                    org.glassfish.flashlight.provider,
-                                    org.glassfish.hk2.osgiresourcelocator
-                                </DynamicImport-Package>
-                            </instructions>
-                            <unpackBundle>true</unpackBundle>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <excludeDependencies>jaxws-eclipselink-plugin,sdo-eclipselink-plugin</excludeDependencies>
+                    <instructions>
+                        <Export-Package>
+                            com.oracle.webservices.*;version=${jaxws.osgiVersion},
+                            com.oracle.xmlns.webservices.jaxws_databinding;version=${jaxws.osgiVersion},
+                            com.sun.istack.ws.*;version=${jaxb.osgiVersion},
+                            com.sun.istack.localization;version=${jaxb.osgiVersion};uses:="com.sun.xml.ws.resources,com.sun.tools.ws.resources",
+                            com.sun.tools.ws.*;version=${jaxws.osgiVersion},
+                            com.sun.wsit.security.*;version=${metro.osgiVersion},
+                            com.sun.xml.messaging.saaj.*;version=${saaj-impl.osgiVersion},
+                            com.sun.xml.registry.*;version=1.0,
+                            com.sun.xml.rpc.plugins;version=${metro.osgiVersion},
+                            com.sun.xml.rpc.security;version=${metro.osgiVersion},
+                            com.sun.xml.rpc.*;version=${jaxrpc-impl.osgiVersion},
+                            com.sun.xml.security.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.api.config.management;version=${jaxws.osgiVersion},
+                            com.sun.xml.ws.api.config.management.policy;version=${jaxws.osgiVersion},
+                            com.sun.xml.ws.api.config.management.jmx;version=${metro.osgiVersion},
+                            com.sun.xml.ws.api.security.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.api.transport.tcp.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.api.tx.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.assembler.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.commons.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.config.management.policy.*;version=${jaxws.osgiVersion},
+                            com.sun.xml.ws.config.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.metro.api.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.policy.config.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.policy.impl.bindings.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.policy.jaxws.*;version=${jaxws.osgiVersion},
+                            com.sun.xml.ws.policy.jcaps.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.policy.localization.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.policy.parser.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.runtime.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.rx.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.security.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.transport.tcp.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.*;version=${jaxws.osgiVersion},
+                            com.sun.xml.wss.*;version=${metro.osgiVersion},
+                            org.jvnet.ws.databinding.*;version=${jaxws.osgiVersion},
+                            org.jvnet.ws.message.*;version=${jaxws.osgiVersion},
+                            org.jvnet.ws.*;version=${jaxws.osgiVersion},
+                            org.apache.jcp.xml.dsig.*;version=${santuario.version},
+                            org.apache.xml.security;version=${santuario.version},
+                            org.apache.xml.security.*;version=${santuario.version}
+                        </Export-Package>
+                        <Import-Package>
+                            javax.activation;version=!;resolution:=optional,
+                            com.ibm.security.util;resolution:=optional,
+                            com.ibm.security.x509;resolution:=optional,
+                            com.sun.istack.*;version=${jaxb.osgiVersion},
+                            com.sun.security.auth.callback;resolution:=optional,
+                            sun.security.action;resolution:=optional,
+                            sun.security.jgss;resolution:=optional,
+                            sun.security.jgss.spi;resolution:=optional,
+                            sun.security.krb5;resolution:=optional,
+                            sun.security.krb5.internal.crypto;resolution:=optional,
+                            sun.security.util;resolution:=optional,
+                            sun.security.x509;resolution:=optional,
+                            com.sun.security.jgss;resolution:=optional,
+                            com.sun.appserv.server;resolution:=optional,
+                            com.sun.enterprise.security.*;resolution:=optional,
+                            com.sun.enterprise.transaction.*;resolution:=optional,
+                            com.sun.enterprise.web.*;resolution:=optional,
+                            org.glassfish.webservice;resolution:=optional,
+                            org.glassfish.webservice.monitoring;resolution:=optional,
+                            com.sun.mail.util;resolution:=optional,
+                            com.sun.msv.*;resolution:=optional,
+                            com.sun.org.apache.xalan.internal.*;resolution:=optional,
+                            com.sun.org.apache.xml.internal.*;resolution:=optional,
+                            com.sun.org.apache.xerces.internal.*;resolution:=optional,
+                            com.sun.xml.bind.api.impl;resolution:=optional,
+                            com.sun.xml.bind.serializer;resolution:=optional,
+                            com.sun.xml.bind.validator;resolution:=optional,
+                            com.sun.xml.rpc.*;resolution:=optional,
+                            com.sun.xml.ws.spi.runtime;resolution:=optional,
+                            com.sun.xml.util;resolution:=optional,
+                            javax.ejb;resolution:=optional;version=3.0,
+                            javax.jws;version=2.0,
+                            javax.jws.soap;version=2.0,
+                            javax.xml.soap.*;version=${saaj-api.osgiVersion},
+                            javax.xml.ws.*;version=${jaxws-api.osgiVersion},
+                            javax.xml.bind.*;version=${jaxb-api.osgiVersion},
+                            org.apache.coyote;resolution:=optional,
+                            javax.xml.crypto.*;resolution:=optional;version=0,
+                            org.apache.tomcat.util.buf;resolution:=optional,
+                            org.iso_relax.verifier.impl;resolution:=optional,
+                            org.jvnet.mimepull;resolution:=optional,
+                            org.relaxng.datatype;resolution:=optional,
+                            org.relaxng.datatype.helpers;resolution:=optional,
+                            org.apache.xml.dtm;resolution:=optional,
+                            org.apache.xml.utils;resolution:=optional,
+                            org.apache.xpath;resolution:=optional,
+                            org.apache.xpath.compiler;resolution:=optional,
+                            org.apache.xpath.functions;resolution:=optional,
+                            org.apache.xpath.objects;resolution:=optional,
+                            org.w3c.dom;resolution:=optional,
+                            org.xml.sax;resolution:=optional,
+                            org.apache.log;resolution:=optional,
+                            org.apache.log4j;resolution:=optional,
+                            org.apache.avalon.framework.logger;resolution:=optional,
+                            *
+                        </Import-Package>
+                        <Private-Package>
+                            com.sun.xml.stream.*,
+                            com.sun.xml.xwss.*;version=${metro.osgiVersion},
+                            com.sun.xml.util.*;version=${metro.osgiVersion};include="XMLCipherAdapter",
+                            javanet.staxutils.*,
+                            org.apache.commons.logging,
+                            org.apache.commons.logging.impl,
+                        </Private-Package>
+                        <DynamicImport-Package>
+                            org.glassfish.flashlight.provider,
+                            org.glassfish.hk2.osgiresourcelocator
+                        </DynamicImport-Package>
+                        <probe-provider-class-names>com.sun.xml.ws.transport.http.servlet.JAXWSRIDeploymentProbeProvider,com.sun.xml.ws.transport.http.servlet.JAXWSRIServletProbeProvider</probe-provider-class-names>
+                    </instructions>
+                    <unpackBundle>true</unpackBundle>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
+                <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <archive>
-                        <manifestFile>${mf.dir}/META-INF/MANIFEST.MF</manifestFile>
-                        <manifestEntries>
-                            <probe-provider-class-names>com.sun.xml.ws.transport.http.servlet.JAXWSRIDeploymentProbeProvider,com.sun.xml.ws.transport.http.servlet.JAXWSRIServletProbeProvider</probe-provider-class-names>
-                        </manifestEntries>
-                    </archive>
-                    <classifier>aix</classifier>
+                    <additionalOptions>
+                        --add-exports java.security.jgss/sun.security.krb5=ALL-UNNAMED
+                        --add-exports java.xml/com.sun.org.apache.xerces.internal.impl.dv.util=ALL-UNNAMED
+                        --add-exports java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED
+                        --add-exports java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED
+                    </additionalOptions>
+                    <excludePackageNames>*.msv.*:xsdlib.*:*com.sun.xml.ws*:com.sun.tools.*:com.sun.enterprise.*:java.*:isorelax.*:src.*:*javanet*:*test*:*ctc*:*glassfish*:*com.sun.istack.tools*:javax.xml.crypto.*:org.apache.xml.security.*:org.apache.jcp.xml.dsig.internal.*:org.apache.commons.*:com.sun.grizzly.*</excludePackageNames>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>META-INF/**</sourceFileExclude>
+                    </sourceFileExcludes>
                 </configuration>
             </plugin>
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <additionalJOptions>
-                                <additionalJOption>--add-modules</additionalJOption>
-                                <additionalJOption>java.activation</additionalJOption>
-                                <additionalJOption>--add-exports</additionalJOption>
-                                <additionalJOption>java.security.jgss/sun.security.krb5=ALL-UNNAMED</additionalJOption>
-                                <additionalJOption>--add-exports</additionalJOption>
-                                <additionalJOption>java.xml/com.sun.org.apache.xerces.internal.impl.dv.util=ALL-UNNAMED</additionalJOption>
-                            </additionalJOptions>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <dependencies>
         <dependency>
-            <groupId>javax.xml.registry</groupId>
-            <artifactId>javax.xml.registry-api</artifactId>
+            <groupId>jakarta.xml.registry</groupId>
+            <artifactId>jakarta.xml.registry-api</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -350,8 +334,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
@@ -359,8 +343,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -390,8 +374,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.xml.rpc</groupId>
-            <artifactId>javax.xml.rpc-api</artifactId>
+            <groupId>jakarta.xml.rpc</groupId>
+            <artifactId>jakarta.xml.rpc-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
@@ -418,7 +402,6 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
         </dependency>
     </dependencies>
     <properties>

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -17,38 +17,31 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>webservices-osgi</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>Metro Web Services Runtime OSGi Bundle</name>
     <description>Metro Web Services Runtime OSGi Bundle</description>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <excludePackageNames>*com.sun.xml.ws*:com.sun.tools.*:com.sun.enterprise.*:java.*:isorelax.*:src.*:*javanet*:*test*:*ctc*:*glassfish*:*com.sun.istack.tools*:javax.xml.crypto.*:org.apache.xml.security.*:org.apache.jcp.xml.dsig.internal.*:org.apache.commons.*:com.sun.grizzly.*</excludePackageNames>
-                </configuration>
-            </plugin>
             <plugin> <!-- want to unpack sources from individual modules -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>attach-meta-inf-entries</id>
-                        <phase>process-sources</phase>
+                        <id>unpack-meta-inf-entries</id>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
                             <excludeTransitive>true</excludeTransitive>
                             <includes>META-INF/services/*, META-INF/metro-default.xml, META-INF/jaxrpc/*</includes>
-                            <excludes>META-INF/services/com.sun.xml.ws.spi.db.*, META-INF/services/com.sun.tools.*, META-INF/services/javax.xml.bind.*, META-INF/services/javax.xml.stream.*, META-INF/services/org.*</excludes>
-                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                            <excludes>META-INF/services/com.sun.xml.ws.spi.db.*, META-INF/services/com.sun.tools.*, META-INF/services/javax.xml.bind.*, META-INF/services/javax.xml.stream.*, META-INF/services/javax.mail.*, META-INF/services/org.*</excludes>
+                            <outputDirectory>${project.build.directory}/generated-sources/resources</outputDirectory>
                         </configuration>
                     </execution>
                     <execution>
@@ -60,8 +53,8 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>javax.xml.registry</groupId>
-                                    <artifactId>javax.xml.registry-api</artifactId>
+                                    <groupId>jakarta.xml.registry</groupId>
+                                    <artifactId>jakarta.xml.registry-api</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
@@ -97,6 +90,20 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>add-meta-inf-entries</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}/generated-sources/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>add-source</goal>
@@ -118,7 +125,7 @@
                         <goals>
                             <goal>enforce</goal>
                         </goals>
-                        <phase>validate</phase>
+                        <phase>initialize</phase>
                         <configuration>
                             <rules>
                                 <requireProperty>
@@ -132,6 +139,14 @@
                                 <requireProperty>
                                     <property>saaj-api.osgiVersion</property>
                                     <message>Property saaj-api.osgiVersion not imported or set!</message>
+                                </requireProperty>
+                                <requireProperty>
+                                    <property>saaj-impl.osgiVersion</property>
+                                    <message>Property saaj-impl.osgiVersion not imported or set!</message>
+                                </requireProperty>
+                                <requireProperty>
+                                    <property>jaxrpc-impl.osgiVersion</property>
+                                    <message>Property jaxrpc-impl.osgiVersion not imported or set!</message>
                                 </requireProperty>
                                 <requireProperty>
                                     <property>jaxws.osgiVersion</property>
@@ -155,178 +170,153 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <executions>
-                    <execution>
-                        <id>osgi-bundle</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>bundle</goal>
-                        </goals>
-                        <configuration>
-                            <excludeDependencies>jaxws-eclipselink-plugin,sdo-eclipselink-plugin</excludeDependencies>
-                            <instructions>
-                                <Export-Package>
-                                    com.oracle.webservices.*;version=${jaxws.osgiVersion},
-                                    com.oracle.xmlns.webservices.jaxws_databinding;version=${jaxws.osgiVersion},
-                                    com.sun.istack.ws.*;version=${jaxb.osgiVersion},
-                                    com.sun.istack.localization;version=${jaxb.osgiVersion};uses:="com.sun.xml.ws.resources,com.sun.tools.ws.resources",
-                                    com.sun.tools.ws.*;version=${jaxws.osgiVersion},
-                                    com.sun.wsit.security.*;version=${metro.osgiVersion},
-                                    com.sun.xml.messaging.saaj.*;version=1.4,
-                                    com.sun.xml.registry.*;version=1.0,
-                                    com.sun.xml.rpc.plugins;version=${metro.osgiVersion},
-                                    com.sun.xml.rpc.security;version=${metro.osgiVersion},
-                                    com.sun.xml.rpc.*;version=1.1.2,
-                                    com.sun.xml.security.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.api.config.management;version=${jaxws.osgiVersion},
-                                    com.sun.xml.ws.api.config.management.policy;version=${jaxws.osgiVersion},
-                                    com.sun.xml.ws.api.config.management.jmx;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.api.security.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.api.transport.tcp.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.api.tx.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.assembler.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.commons.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.config.management.policy.*;version=${jaxws.osgiVersion},
-                                    com.sun.xml.ws.config.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.metro.api.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.policy.config.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.policy.impl.bindings.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.policy.jaxws.*;version=${jaxws.osgiVersion},
-                                    com.sun.xml.ws.policy.jcaps.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.policy.localization.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.policy.parser.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.runtime.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.rx.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.security.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.transport.tcp.*;version=${metro.osgiVersion},
-                                    com.sun.xml.ws.*;version=${jaxws.osgiVersion},
-                                    com.sun.xml.wss.*;version=${metro.osgiVersion},
-                                    org.jvnet.ws.databinding.*;version=${jaxws.osgiVersion},
-                                    org.jvnet.ws.message.*;version=${jaxws.osgiVersion},
-                                    org.jvnet.ws.*;version=${jaxws.osgiVersion},
-                                    org.apache.jcp.xml.dsig.*;version=${santuario.version},
-                                    org.apache.xml.security;version=${santuario.version},
-                                    org.apache.xml.security.*;version=${santuario.version}
-                                </Export-Package>
-                                <Import-Package>
-                                    com.ibm.security.util;resolution:=optional,
-                                    com.ibm.security.x509;resolution:=optional,
-                                    com.sun.istack.*;version=${jaxb.osgiVersion},
-                                    com.sun.security.auth.callback;resolution:=optional,
-                                    sun.security.action;resolution:=optional,
-                                    sun.security.jgss;resolution:=optional,
-                                    sun.security.jgss.spi;resolution:=optional,
-                                    sun.security.krb5;resolution:=optional,
-                                    sun.security.krb5.internal.crypto;resolution:=optional,
-                                    sun.security.util;resolution:=optional,
-                                    sun.security.x509;resolution:=optional,
-                                    com.sun.security.jgss;resolution:=optional,
-                                    com.sun.appserv.server;resolution:=optional,
-                                    com.sun.enterprise.security.*;resolution:=optional,
-                                    com.sun.enterprise.transaction.*;resolution:=optional,
-                                    com.sun.enterprise.web.*;resolution:=optional,
-                                    org.glassfish.webservice;resolution:=optional,
-                                    org.glassfish.webservice.monitoring;resolution:=optional,
-                                    com.sun.mail.util;resolution:=optional,
-                                    com.sun.msv.*;resolution:=optional,
-                                    com.sun.org.apache.xalan.internal.*;resolution:=optional,
-                                    com.sun.org.apache.xml.internal.*;resolution:=optional,
-                                    com.sun.org.apache.xerces.internal.*;resolution:=optional,
-                                    com.sun.xml.bind.api.impl;resolution:=optional,
-                                    com.sun.xml.bind.serializer;resolution:=optional,
-                                    com.sun.xml.bind.validator;resolution:=optional,
-                                    com.sun.xml.rpc.*;resolution:=optional,
-                                    com.sun.xml.ws.spi.runtime;resolution:=optional,
-                                    javax.ejb;resolution:=optional;version=3.0,
-                                    javax.jws;version=2.0,
-                                    javax.jws.soap;version=2.0,
-                                    javax.xml.soap.*;version=${saaj-api.osgiVersion},
-                                    javax.xml.ws.*;version=${jaxws-api.osgiVersion},
-                                    javax.xml.bind.*;version=${jaxb-api.osgiVersion},
-                                    org.apache.coyote;resolution:=optional,
-                                    javax.xml.crypto.*;resolution:=optional;version=0,
-                                    org.apache.tomcat.util.buf;resolution:=optional,
-                                    org.iso_relax.verifier.impl;resolution:=optional,
-                                    org.jvnet.mimepull;resolution:=optional,
-                                    org.relaxng.datatype;resolution:=optional,
-                                    org.relaxng.datatype.helpers;resolution:=optional,
-                                    org.apache.xml.dtm;resolution:=optional,
-                                    org.apache.xml.utils;resolution:=optional,
-                                    org.apache.xpath;resolution:=optional,
-                                    org.apache.xpath.compiler;resolution:=optional,
-                                    org.apache.xpath.functions;resolution:=optional,
-                                    org.apache.xpath.objects;resolution:=optional,
-                                    org.w3c.dom;resolution:=optional,
-                                    org.xml.sax;resolution:=optional,
-                                    org.apache.log;resolution:=optional,
-                                    org.apache.log4j;resolution:=optional,
-                                    org.apache.avalon.framework.logger;resolution:=optional,
-                                    *
-                                </Import-Package>
-                                <Private-Package>
-                                    com.sun.xml.stream.*,
-                                    com.sun.xml.xwss.*;version=${metro.osgiVersion},
-                                    com.sun.xml.util.*;version=${metro.osgiVersion};include="XMLCipherAdapter",
-                                    javanet.staxutils.*,
-                                    org.apache.commons.logging,
-                                    org.apache.commons.logging.impl,
-                                </Private-Package>
-                                <DynamicImport-Package>
-                                    org.glassfish.flashlight.provider,
-                                    org.glassfish.hk2.osgiresourcelocator
-                                </DynamicImport-Package>
-                            </instructions>
-                            <unpackBundle>true</unpackBundle>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <excludeDependencies>jaxws-eclipselink-plugin,sdo-eclipselink-plugin</excludeDependencies>
+                    <instructions>
+                        <Export-Package>
+                            com.oracle.webservices.*;version=${jaxws.osgiVersion},
+                            com.oracle.xmlns.webservices.jaxws_databinding;version=${jaxws.osgiVersion},
+                            com.sun.istack.ws.*;version=${jaxb.osgiVersion},
+                            com.sun.istack.localization;version=${jaxb.osgiVersion};uses:="com.sun.xml.ws.resources,com.sun.tools.ws.resources",
+                            com.sun.tools.ws.*;version=${jaxws.osgiVersion},
+                            com.sun.wsit.security.*;version=${metro.osgiVersion},
+                            com.sun.xml.messaging.saaj.*;version=${saaj-impl.osgiVersion},
+                            com.sun.xml.registry.*;version=1.0,
+                            com.sun.xml.rpc.plugins;version=${metro.osgiVersion},
+                            com.sun.xml.rpc.security;version=${metro.osgiVersion},
+                            com.sun.xml.rpc.*;version=${jaxrpc-impl.osgiVersion},
+                            com.sun.xml.security.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.api.config.management;version=${jaxws.osgiVersion},
+                            com.sun.xml.ws.api.config.management.policy;version=${jaxws.osgiVersion},
+                            com.sun.xml.ws.api.config.management.jmx;version=${metro.osgiVersion},
+                            com.sun.xml.ws.api.security.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.api.transport.tcp.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.api.tx.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.assembler.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.commons.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.config.management.policy.*;version=${jaxws.osgiVersion},
+                            com.sun.xml.ws.config.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.metro.api.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.policy.config.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.policy.impl.bindings.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.policy.jaxws.*;version=${jaxws.osgiVersion},
+                            com.sun.xml.ws.policy.jcaps.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.policy.localization.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.policy.parser.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.runtime.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.rx.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.security.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.transport.tcp.*;version=${metro.osgiVersion},
+                            com.sun.xml.ws.*;version=${jaxws.osgiVersion},
+                            com.sun.xml.wss.*;version=${metro.osgiVersion},
+                            org.jvnet.ws.databinding.*;version=${jaxws.osgiVersion},
+                            org.jvnet.ws.message.*;version=${jaxws.osgiVersion},
+                            org.jvnet.ws.*;version=${jaxws.osgiVersion},
+                            org.apache.jcp.xml.dsig.*;version=${santuario.version},
+                            org.apache.xml.security;version=${santuario.version},
+                            org.apache.xml.security.*;version=${santuario.version}
+                        </Export-Package>
+                        <Import-Package>
+                            javax.activation;version=!,
+                            javax.xml.crypto;version=!,
+                            javax.xml.crypto.dom;version=!,
+                            javax.xml.crypto.dsig;version=!,
+                            javax.xml.crypto.dsig.dom;version=!,
+                            javax.xml.crypto.dsig.keyinfo;version=!,
+                            javax.xml.crypto.dsig.spec;version=!,
+                            com.ibm.security.util;resolution:=optional,
+                            com.ibm.security.x509;resolution:=optional,
+                            com.sun.istack.*;version=${jaxb.osgiVersion},
+                            com.sun.security.auth.callback;resolution:=optional,
+                            sun.security.action;resolution:=optional,
+                            sun.security.jgss;resolution:=optional,
+                            sun.security.jgss.spi;resolution:=optional,
+                            sun.security.krb5;resolution:=optional,
+                            sun.security.krb5.internal.crypto;resolution:=optional,
+                            sun.security.util;resolution:=optional,
+                            sun.security.x509;resolution:=optional,
+                            com.sun.security.jgss;resolution:=optional,
+                            com.sun.appserv.server;resolution:=optional,
+                            com.sun.enterprise.security.*;resolution:=optional,
+                            com.sun.enterprise.transaction.*;resolution:=optional,
+                            com.sun.enterprise.web.*;resolution:=optional,
+                            org.glassfish.webservice;resolution:=optional,
+                            org.glassfish.webservice.monitoring;resolution:=optional,
+                            com.sun.mail.util;resolution:=optional,
+                            com.sun.msv.*;resolution:=optional,
+                            com.sun.org.apache.xalan.internal.*;resolution:=optional,
+                            com.sun.org.apache.xml.internal.*;resolution:=optional,
+                            com.sun.org.apache.xerces.internal.*;resolution:=optional,
+                            com.sun.xml.bind.api.impl;resolution:=optional,
+                            com.sun.xml.bind.serializer;resolution:=optional,
+                            com.sun.xml.bind.validator;resolution:=optional,
+                            com.sun.xml.rpc.*;resolution:=optional,
+                            com.sun.xml.ws.spi.runtime;resolution:=optional,
+                            javax.ejb;resolution:=optional;version=3.0,
+                            javax.jws;version=2.0,
+                            javax.jws.soap;version=2.0,
+                            javax.xml.soap.*;version=${saaj-api.osgiVersion},
+                            javax.xml.ws.*;version=${jaxws-api.osgiVersion},
+                            javax.xml.bind.*;version=${jaxb-api.osgiVersion},
+                            org.apache.coyote;resolution:=optional,
+                            org.apache.tomcat.util.buf;resolution:=optional,
+                            org.iso_relax.verifier.impl;resolution:=optional,
+                            org.jvnet.mimepull;resolution:=optional,
+                            org.relaxng.datatype;resolution:=optional,
+                            org.relaxng.datatype.helpers;resolution:=optional,
+                            org.apache.xml.dtm;resolution:=optional,
+                            org.apache.xml.utils;resolution:=optional,
+                            org.apache.xpath;resolution:=optional,
+                            org.apache.xpath.compiler;resolution:=optional,
+                            org.apache.xpath.functions;resolution:=optional,
+                            org.apache.xpath.objects;resolution:=optional,
+                            org.w3c.dom;resolution:=optional,
+                            org.xml.sax;resolution:=optional,
+                            org.apache.log;resolution:=optional,
+                            org.apache.log4j;resolution:=optional,
+                            org.apache.avalon.framework.logger;resolution:=optional,
+                            *
+                        </Import-Package>
+                        <Private-Package>
+                            com.sun.xml.stream.*,
+                            com.sun.xml.xwss.*;version=${metro.osgiVersion},
+                            com.sun.xml.util.*;version=${metro.osgiVersion};include="XMLCipherAdapter",
+                            javanet.staxutils.*,
+                            org.apache.commons.logging,
+                            org.apache.commons.logging.impl,
+                        </Private-Package>
+                        <DynamicImport-Package>
+                            org.glassfish.flashlight.provider,
+                            org.glassfish.hk2.osgiresourcelocator
+                        </DynamicImport-Package>
+                        <probe-provider-class-names>com.sun.xml.ws.transport.http.servlet.JAXWSRIDeploymentProbeProvider,com.sun.xml.ws.transport.http.servlet.JAXWSRIServletProbeProvider</probe-provider-class-names>
+                    </instructions>
+                    <unpackBundle>true</unpackBundle>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
+                <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <archive>
-                        <manifestFile>${mf.dir}/META-INF/MANIFEST.MF</manifestFile>
-                        <manifestEntries>
-                            <probe-provider-class-names>com.sun.xml.ws.transport.http.servlet.JAXWSRIDeploymentProbeProvider,com.sun.xml.ws.transport.http.servlet.JAXWSRIServletProbeProvider</probe-provider-class-names>
-                        </manifestEntries>
-                    </archive>
+                    <additionalOptions>
+                        --add-exports java.security.jgss/sun.security.krb5=ALL-UNNAMED
+                        --add-exports java.xml/com.sun.org.apache.xerces.internal.impl.dv.util=ALL-UNNAMED
+                        --add-exports java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED
+                        --add-exports java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED
+                    </additionalOptions>
+                    <excludePackageNames>*com.sun.xml.ws*:com.sun.tools.*:com.sun.enterprise.*:java.*:isorelax.*:src.*:*javanet*:*test*:*ctc*:*glassfish*:*com.sun.istack.tools*:javax.xml.crypto.*:org.apache.xml.security.*:org.apache.jcp.xml.dsig.internal.*:org.apache.commons.*:com.sun.grizzly.*</excludePackageNames>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>META-INF/**</sourceFileExclude>
+                    </sourceFileExcludes>
                 </configuration>
             </plugin>
         </plugins>
     </build>
 
-   <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-              <plugins>
-                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <additionalJOptions>
-                            <additionalJOption>--add-modules</additionalJOption>
-                            <additionalJOption>java.activation</additionalJOption>
-                            <additionalJOption>--add-exports</additionalJOption>
-                            <additionalJOption>java.security.jgss/sun.security.krb5=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports</additionalJOption>
-                            <additionalJOption>java.xml/com.sun.org.apache.xerces.internal.impl.dv.util=ALL-UNNAMED</additionalJOption>
-                        </additionalJOptions>
-                    </configuration>
-                </plugin>
-              </plugins>
-             </build>
-        </profile>
-    </profiles>
-
     <dependencies>
         <dependency>
-            <groupId>javax.xml.registry</groupId>
-            <artifactId>javax.xml.registry-api</artifactId>
+            <groupId>jakarta.xml.registry</groupId>
+            <artifactId>jakarta.xml.registry-api</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -348,8 +338,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
          <dependency>
             <groupId>org.apache.ant</groupId>
@@ -357,8 +347,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -389,8 +379,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.xml.rpc</groupId>
-            <artifactId>javax.xml.rpc-api</artifactId>
+            <groupId>jakarta.xml.rpc</groupId>
+            <artifactId>jakarta.xml.rpc-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -400,10 +391,12 @@
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
             <artifactId>woodstox-core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jvnet.mimepull</groupId>
             <artifactId>mimepull</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
@@ -422,11 +415,10 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
         </dependency>
     </dependencies>
     <properties>
-        <generated.sources.dir>${project.build.directory}/generated-sources</generated.sources.dir>
+        <generated.sources.dir>${project.build.directory}/generated-sources/src</generated.sources.dir>
         <cobertura.skip>true</cobertura.skip>
         <mf.dir>${project.build.outputDirectory}</mf.dir>
     </properties>

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>webservices-rt</artifactId>
@@ -40,84 +40,8 @@
                             <goal>unpack</goal>
                         </goals>
                         <configuration>
+                            <excludes>module-info*,pom.xml</excludes>
                             <artifactItems>
-                                <artifactItem>
-                                    <groupId>com.sun.org.apache.xml.internal</groupId>
-                                    <artifactId>resolver</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.codehaus.woodstox</groupId>
-                                    <artifactId>stax2-api</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.fasterxml.woodstox</groupId>
-                                    <artifactId>woodstox-core</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.jvnet.mimepull</groupId>
-                                    <artifactId>mimepull</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.jvnet.staxex</groupId>
-                                    <artifactId>stax-ex</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.sun.xml.ws</groupId>
-                                    <artifactId>policy</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.sun.xml.messaging.saaj</groupId>
-                                    <artifactId>saaj-impl</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>net.java.dev.stax-utils</groupId>
-                                    <artifactId>stax-utils</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.sun.xml.stream.buffer</groupId>
-                                    <artifactId>streambuffer</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.sun.xml.fastinfoset</groupId>
-                                    <artifactId>FastInfoset</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>com.sun.xml.bind</groupId>
-                                    <artifactId>jaxb-impl</artifactId>
-                                    <classifier>sources</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                </artifactItem>
                                 <artifactItem>
                                     <groupId>${project.parent.groupId}</groupId>
                                     <artifactId>wsit-api</artifactId>
@@ -135,6 +59,123 @@
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
+                                    <groupId>com.sun.org.apache.xml.internal</groupId>
+                                    <artifactId>resolver</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.glassfish.jaxb</groupId>
+                                    <artifactId>jaxb-runtime</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.glassfish.jaxb</groupId>
+                                    <artifactId>txw2</artifactId>
+                                    <!-- should JAXB-RI export this ? -->
+                                    <version>${jaxb.version}</version>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.istack</groupId>
+                                    <artifactId>istack-commons-runtime</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.fastinfoset</groupId>
+                                    <artifactId>FastInfoset</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.messaging.saaj</groupId>
+                                    <artifactId>saaj-impl</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.rpc</groupId>
+                                    <artifactId>jaxrpc-impl</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                    <excludes>module-info*,META-INF/jaxrpc/ToolPlugin.xml</excludes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.rpc</groupId>
+                                    <artifactId>jaxrpc-spi</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.santuario</groupId>
+                                    <artifactId>xmlsec</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                    <excludes>module-info*,pom.xml,javax/xml/crypto/**</excludes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>commons-logging</groupId>
+                                    <artifactId>commons-logging</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.stream.buffer</groupId>
+                                    <artifactId>streambuffer</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.ws</groupId>
+                                    <artifactId>jaxws-rt</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                    <excludes>module-info*,com/sun/xml/ws/util/version.properties,META-INF/jaxws-tubes-default.xml</excludes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.ws</groupId>
+                                    <artifactId>policy</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>net.java.dev.stax-utils</groupId>
+                                    <artifactId>stax-utils</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.fasterxml.woodstox</groupId>
+                                    <artifactId>woodstox-core</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.codehaus.woodstox</groupId>
+                                    <artifactId>stax2-api</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
                                     <groupId>org.glassfish.external</groupId>
                                     <artifactId>management-api</artifactId>
                                     <classifier>sources</classifier>
@@ -143,9 +184,9 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.glassfish.gmbal</groupId>
-                                    <artifactId>gmbal-source</artifactId>
+                                    <artifactId>gmbal</artifactId>
+                                    <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
-                                    <version>3.1.0-b001</version>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
@@ -156,8 +197,15 @@
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>com.sun.xml.ws</groupId>
-                                    <artifactId>jaxws-rt</artifactId>
+                                    <groupId>org.jvnet.staxex</groupId>
+                                    <artifactId>stax-ex</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.jvnet.mimepull</groupId>
+                                    <artifactId>mimepull</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
@@ -219,13 +267,16 @@
                                 <includes>
                                     <include>${project.parent.groupId}:wsit*</include>
                                     <include>com.sun.org.apache.xml.internal:resolver</include>
-                                    <include>com.sun.xml.bind:jaxb-impl</include>
+                                    <include>org.glassfish.jaxb:jaxb-runtime</include>
+                                    <include>org.glassfish.jaxb:txw2</include>
+                                    <include>com.sun.istack:istack-commons-runtime</include>
                                     <include>com.sun.xml.fastinfoset:FastInfoset</include>
                                     <include>com.sun.xml.messaging.saaj:saaj-impl</include>
                                     <include>com.sun.xml.registry:jaxr-impl</include>
                                     <include>com.sun.xml.rpc:jaxrpc-impl</include>
                                     <include>com.sun.xml.rpc:jaxrpc-spi</include>
                                     <include>org.apache.santuario:xmlsec</include>
+                                    <include>commons-logging:commons-logging</include>
                                     <include>com.sun.xml.stream.buffer:streambuffer</include>
                                     <include>com.sun.xml.ws:jaxws-rt</include>
                                     <include>com.sun.xml.ws:policy</include>
@@ -243,9 +294,22 @@
                             </artifactSet>
                             <filters>
                                 <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.*</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
                                     <artifact>com.sun.xml.rpc:jaxrpc-impl</artifact>
                                     <excludes>
                                         <exclude>META-INF/jaxrpc/ToolPlugin.xml</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.santuario:xmlsec</artifact>
+                                    <excludes>
+                                        <!-- included in JDK -->
+                                        <exclude>javax/xml/crypto/**</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>
@@ -256,17 +320,36 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Class-Path>webservices-api.jar webservices-extra.jar webservices-rt_l10n.jar webservices-rt_ja.jar webservices-rt_zh.jar webservices-rt_fr.jar webservices-rt_de.jar webservices-rt_es.jar webservices-rt_it.jar webservices-rt_sw.jar webservices-rt_ko.jar webservices-rt_zh_TW.jar</Class-Path>
+                                        <Multi-Release>true</Multi-Release>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>
+                        --add-exports java.security.jgss/sun.security.krb5=ALL-UNNAMED
+                        --add-exports java.xml/com.sun.org.apache.xerces.internal.impl.dv.util=ALL-UNNAMED
+                        --add-exports java.desktop/sun.font=ALL-UNNAMED
+                    </additionalOptions>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>META-INF/**</sourceFileExclude>
+                        <sourceFileExclude>**/msv/**</sourceFileExclude>
+                        <sourceFileExclude>**/osgi/**</sourceFileExclude>
+                        <sourceFileExclude>org/apache/**</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
             </plugin>
         </plugins>
         <resources>
@@ -277,29 +360,6 @@
         </resources>
     </build>
 
-    <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-              <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <additionalJOptions>
-                            <additionalJOption>--add-modules</additionalJOption>
-                            <additionalJOption>java.activation</additionalJOption>
-                        </additionalJOptions>
-                    </configuration>
-                </plugin>
-              </plugins>
-             </build>
-        </profile>
-    </profiles>
-
     <dependencies>
 
         <!-- Provided dependencies -->
@@ -309,13 +369,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.rpc</groupId>
-            <artifactId>javax.xml.rpc-api</artifactId>
+            <groupId>jakarta.xml.rpc</groupId>
+            <artifactId>jakarta.xml.rpc-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.registry</groupId>
-            <artifactId>javax.xml.registry-api</artifactId>
+            <groupId>jakarta.xml.registry</groupId>
+            <artifactId>jakarta.xml.registry-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -329,18 +389,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.ejb</artifactId>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.resource</groupId>
-            <artifactId>connector-api</artifactId>
+            <groupId>jakarta.resource</groupId>
+            <artifactId>jakarta.resource-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -349,8 +409,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -424,8 +484,12 @@
             <artifactId>gmbal</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.istack</groupId>
+            <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.external</groupId>

--- a/wsit/bundles/webservices-tools/pom.xml
+++ b/wsit/bundles/webservices-tools/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>webservices-tools</artifactId>
@@ -40,19 +40,70 @@
                             <goal>unpack</goal>
                         </goals>
                         <configuration>
+                            <excludes>module-info*</excludes>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>com.sun.xml.bind</groupId>
+                                    <groupId>org.glassfish.jaxb</groupId>
                                     <artifactId>jaxb-xjc</artifactId>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
-                                    <!-- resolver bin is included in webservervices-rt -->
-                                    <excludes>com\/sun\/org\/**</excludes>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>com.sun.xml.bind</groupId>
+                                    <groupId>org.glassfish.jaxb</groupId>
                                     <artifactId>jaxb-jxc</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.glassfish.jaxb</groupId>
+                                    <artifactId>codemodel</artifactId>
+                                    <!-- should JAXB-RI export this ? -->
+                                    <version>${codemodel.version}</version>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.glassfish.jaxb</groupId>
+                                    <artifactId>xsom</artifactId>
+                                    <!-- should JAXB-RI export this ? -->
+                                    <version>${xsom.version}</version>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.istack</groupId>
+                                    <artifactId>istack-commons-tools</artifactId>
+                                    <!-- should JAXB-RI export this ? -->
+                                    <version>${istack.version}</version>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.dtd-parser</groupId>
+                                    <artifactId>dtd-parser</artifactId>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.bind.external</groupId>
+                                    <artifactId>rngom</artifactId>
+                                    <!-- should JAXB-RI export this ? -->
+                                    <version>${relaxng.version}</version>
+                                    <classifier>sources</classifier>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${generated.sources.dir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.sun.xml.bind.external</groupId>
+                                    <artifactId>relaxng-datatype</artifactId>
+                                    <!-- should JAXB-RI export this ? -->
+                                    <version>${relaxng.version}</version>
                                     <classifier>sources</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${generated.sources.dir}</outputDirectory>
@@ -100,25 +151,33 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.sun.xml.ws:jaxws-tools</include>
-                                    <include>com.sun.xml.bind:jaxb-xjc</include>
-                                    <include>com.sun.xml.bind:jaxb-jxc</include>
+                                    <include>org.glassfish.jaxb:jaxb-xjc</include>
+                                    <include>org.glassfish.jaxb:jaxb-jxc</include>
+                                    <include>org.glassfish.jaxb:codemodel</include>
+                                    <include>org.glassfish.jaxb:xsom</include>
+                                    <include>com.sun.istack:istack-commons-tools</include>
+                                    <include>com.sun.xml.dtd-parser:dtd-parser</include>
+                                    <include>com.sun.xml.bind.external:rngom</include>
+                                    <include>com.sun.xml.bind.external:relaxng-datatype</include>
                                 </includes>
                             </artifactSet>
                             <filters>
                                 <filter>
-                                    <artifact>com.sun.xml.bind:jaxb-xjc</artifact>
+                                    <artifact>*:*</artifact>
                                     <excludes>
-                                        <exclude>META-INF/LICENSE.txt</exclude>
+                                        <exclude>module-info.java</exclude>
                                         <exclude>META-INF/jing-copying.html</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Main-Class>com.sun.tools.ws.WsImport</Main-Class>
                                         <Class-Path>webservices-rt.jar</Class-Path>
+                                        <Multi-Release>true</Multi-Release>
                                     </manifestEntries>
                                 </transformer>
                             </transformers>
@@ -126,72 +185,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <minmemory>128m</minmemory>
+                    <maxmemory>512m</maxmemory>
+                    <additionalDependencies>
+                        <dependency>
+                            <groupId>com.sun.org.apache.xml.internal</groupId>
+                            <artifactId>resolver</artifactId>
+                            <version>${resolver.version}</version>
+                        </dependency>
+                    </additionalDependencies>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>META-INF/**</sourceFileExclude>
+                    </sourceFileExcludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
-    <profiles>
-
-        <profile>
-            <id>release</id>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <minmemory>128m</minmemory>
-                                <maxmemory>512m</maxmemory>
-                            </configuration>
-                            <executions>
-                                <execution>
-                                    <id>attach-javadocs</id>
-                                    <phase>install</phase>
-                                    <goals>
-                                        <goal>jar</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <minmemory>128m</minmemory>
-                                <maxmemory>512m</maxmemory>
-                                <additionalJOptions>
-                                  <additionalJOption>--add-modules</additionalJOption>
-                                  <additionalJOption>java.activation</additionalJOption>
-                               </additionalJOptions>
-                            </configuration>
-                            <executions>
-                                <execution>
-                                    <id>attach-javadocs</id>
-                                    <phase>install</phase>
-                                    <goals>
-                                        <goal>jar</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-    </profiles>
 
     <dependencies>
         <!-- Shaded dependencies -->
@@ -200,11 +213,11 @@
             <artifactId>jaxws-tools</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
+            <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-xjc</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
+            <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-jxc</artifactId>
         </dependency>
 
@@ -223,10 +236,6 @@
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
         </dependency>
     </dependencies>
     <properties>

--- a/wsit/bundles/wsit-api/pom.xml
+++ b/wsit/bundles/wsit-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wsit-api</artifactId>
@@ -153,6 +153,7 @@
                             <createSourcesJar>false</createSourcesJar>
                             <!--minimizeJar>true</minimizeJar-->
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>

--- a/wsit/bundles/wsit-impl/pom.xml
+++ b/wsit/bundles/wsit-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>bundles</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wsit-impl</artifactId>
@@ -189,6 +189,7 @@
                             <createSourcesJar>false</createSourcesJar>
                             <!--minimizeJar>true</minimizeJar-->
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
@@ -201,38 +202,14 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <excludePackageNames>com.sun.xml.ws.*</excludePackageNames>
+                    <additionalOptions>
+                        --add-exports java.security.jgss/sun.security.krb5=ALL-UNNAMED
+                        --add-exports java.xml/com.sun.org.apache.xerces.internal.impl.dv.util=ALL-UNNAMED
+                    </additionalOptions>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-              <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <excludePackageNames>com.sun.xml.ws.*</excludePackageNames>
-                        <additionalJOptions>
-                            <additionalJOption>--add-modules</additionalJOption>
-                            <additionalJOption>java.activation</additionalJOption>
-                            <additionalJOption>--add-exports</additionalJOption>
-                            <additionalJOption>java.security.jgss/sun.security.krb5=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports</additionalJOption>
-                            <additionalJOption>java.xml/com.sun.org.apache.xerces.internal.impl.dv.util=ALL-UNNAMED</additionalJOption>
-                        </additionalJOptions>
-                    </configuration>
-                </plugin>
-              </plugins>
-             </build>
-        </profile>
-    </profiles>
 
     <dependencies>
 
@@ -243,8 +220,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -258,18 +235,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.ejb</artifactId>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.resource</groupId>
-            <artifactId>connector-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/wsit/docs/getting-started/pom.xml
+++ b/wsit/docs/getting-started/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>docs</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>getting-started</artifactId>

--- a/wsit/docs/guide/pom.xml
+++ b/wsit/docs/guide/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>docs</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>guide</artifactId>

--- a/wsit/docs/pom.xml
+++ b/wsit/docs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>metro-project</artifactId>
         <groupId>org.glassfish.metro</groupId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>docs</artifactId>

--- a/wsit/metro-cm/metro-cm-api/pom.xml
+++ b/wsit/metro-cm/metro-cm-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-cm-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-cm-api</artifactId>
@@ -50,8 +50,8 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/metro-cm/metro-cm-impl/pom.xml
+++ b/wsit/metro-cm/metro-cm-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-cm-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-cm-impl</artifactId>
@@ -45,8 +45,8 @@
     <dependencies>
         <!-- Compile scope -->
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/metro-cm/pom.xml
+++ b/wsit/metro-cm/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-cm-project</artifactId>

--- a/wsit/metro-commons/pom.xml
+++ b/wsit/metro-commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-commons</artifactId>
@@ -31,28 +31,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-maven-plugin</artifactId>
-                <inherited>true</inherited>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <inherited>true</inherited>
             </plugin>
         </plugins>
     </build>

--- a/wsit/metro-config/metro-config-api/pom.xml
+++ b/wsit/metro-config/metro-config-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-config</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-config-api</artifactId>
@@ -31,14 +31,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-maven-plugin</artifactId>
-                <inherited>true</inherited>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <inherited>true</inherited>
             </plugin>
         </plugins>
     </build>
@@ -54,12 +48,12 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/metro-config/metro-config-impl/pom.xml
+++ b/wsit/metro-config/metro-config-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-config</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-config-impl</artifactId>
@@ -59,37 +59,6 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-              <plugins>
-                <plugin>
-                    <!-- TODO: Remove exlusion of tests once adapted to maven project structure -->
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <excludes>
-                            <exclude>
-                                com/sun/xml/ws/policy/parser/PolicyConfigParserTest.java
-                            </exclude>
-                            <exclude>
-                                com/sun/xml/ws/policy/parser/PolicyWSDLParserExtensionTest.java
-                            </exclude>
-                        </excludes>
-                        <argLine>
-                           --add-modules java.activation
-                        </argLine>
-                    </configuration>
-                </plugin>
-              </plugins>
-             </build>
-        </profile>
-    </profiles>
-
     <dependencies>
         <!-- Compile scope -->
         <dependency>
@@ -102,8 +71,8 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/metro-config/pom.xml
+++ b/wsit/metro-config/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-config</artifactId>

--- a/wsit/metro-runtime/metro-runtime-api/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-runtime</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-runtime-api</artifactId>
@@ -33,14 +33,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-maven-plugin</artifactId>
-                <inherited>true</inherited>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <inherited>true</inherited>
             </plugin>
         </plugins>
     </build>
@@ -56,8 +50,8 @@
             <artifactId>gmbal</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/metro-runtime/metro-runtime-impl/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-runtime</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-runtime-impl</artifactId>
@@ -45,28 +45,6 @@
         </plugins>
     </build>
 
-   <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-              <plugins>
-                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <argLine>
-                           --add-modules java.activation
-                        </argLine>
-                    </configuration>
-                </plugin>
-              </plugins>
-             </build>
-        </profile>
-    </profiles>
-
     <dependencies>
         <!-- Compile scope -->
         <dependency>
@@ -78,12 +56,12 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
@@ -94,8 +72,8 @@
             <artifactId>policy</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.stream.buffer</groupId>

--- a/wsit/metro-runtime/pom.xml
+++ b/wsit/metro-runtime/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>metro-runtime</artifactId>

--- a/wsit/pom.xml
+++ b/wsit/pom.xml
@@ -20,12 +20,12 @@
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-bom-ext</artifactId>
         <relativePath>boms/bom-ext/pom.xml</relativePath>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.metro</groupId>
     <artifactId>metro-project</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Metro Web Services Stack Project</name>
 
@@ -114,7 +114,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>1.12</version>
+                    <version>3.0.0</version>
                     <executions>
                         <execution>
                             <id>jaxb.version</id>
@@ -172,6 +172,17 @@
                             </configuration>
                         </execution>
                         <execution>
+                            <id>saaj-impl.version</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>parse-version</goal>
+                            </goals>
+                            <configuration>
+                                <propertyPrefix>saaj-impl</propertyPrefix>
+                                <versionString>${saaj-impl.version}</versionString>
+                            </configuration>
+                        </execution>
+                        <execution>
                             <id>mail.version</id>
                             <phase>validate</phase>
                             <goals>
@@ -183,6 +194,17 @@
                             </configuration>
                         </execution>
                         <execution>
+                            <id>jaxrpc-impl.version</id>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>parse-version</goal>
+                            </goals>
+                            <configuration>
+                                <propertyPrefix>jaxrpc-impl</propertyPrefix>
+                                <versionString>${jaxrpc-impl.version}</versionString>
+                            </configuration>
+                        </execution>
+                        <execution>
                             <id>metro.version</id>
                             <phase>validate</phase>
                             <goals>
@@ -190,6 +212,25 @@
                             </goals>
                             <configuration>
                                 <propertyPrefix>metro</propertyPrefix>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>add-legal-resource</id>
+                            <phase>generate-resources</phase>
+                            <goals>
+                                <goal>add-resource</goal>
+                            </goals>
+                            <configuration>
+                                <resources>
+                                    <resource>
+                                        <directory>${legal.doc.source}</directory>
+                                        <includes>
+                                            <include>NOTICE.md</include>
+                                            <include>LICENSE.md</include>
+                                        </includes>
+                                        <targetPath>META-INF</targetPath>
+                                    </resource>
+                                </resources>
                             </configuration>
                         </execution>
                         <execution>
@@ -273,12 +314,12 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>4.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.8.0</version>
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
@@ -315,7 +356,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.3.1</version>
+                    <version>3.1.0</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -345,7 +386,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20</version>
+                    <version>3.0.0-M1</version>
                     <configuration>
                         <forkMode>once</forkMode>
                         <childDelegation>false</childDelegation>
@@ -384,7 +425,7 @@
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>1.42</version>
+                    <version>1.50</version>
                     <configuration>
                         <templateFile>legal/maintenance/copyright.txt</templateFile>
                         <excludeFile>legal/maintenance/copyright-exclude</excludeFile>
@@ -407,29 +448,7 @@
                         <doclint>none</doclint>
                         <minmemory>128m</minmemory>
                         <maxmemory>768m</maxmemory>
-                        <sourcepath>${project.build.sourceDirectory}:target/generated-sources/rsrc-gen</sourcepath>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.glassfish.build</groupId>
-                    <artifactId>gfnexus-maven-plugin</artifactId>
-                    <version>0.20</version>
-                    <configuration>
-                        <nexusRepoUrl>https://maven.java.net/</nexusRepoUrl>
-                        <nexusRepoId>jvnet-nexus-staging</nexusRepoId>
-                        <stagingRepos>
-                            <stagingRepo>
-                                <ref>org.glassfish.metro:webservices-rt:${project.version}:jar</ref>
-                                <profile>org.glassfish.metro</profile>
-                            </stagingRepo>
-                        </stagingRepos>
-                        <promotionProfile>metro</promotionProfile>
-                        <message>metro-${project.version}}</message>
+                        <!--<sourcepath>${project.build.sourceDirectory}:target/generated-sources/rsrc-gen</sourcepath>-->
                     </configuration>
                 </plugin>
             </plugins>
@@ -463,39 +482,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <inherited>true</inherited>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <inherited>true</inherited>
-                <configuration>
-                    <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.6</version>
-                <configuration>
-                    <reportPlugins>
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>findbugs-maven-plugin</artifactId>
-                            <version>${findbugs.version}</version>
-                            <configuration>
-                                <skip>${findbugs.skip}</skip>
-                                <threshold>${findbugs.threshold}</threshold>
-                                <excludeFilterFile>
-                                    ${findbugs.common},${findbugs.exclude}
-                                </excludeFilterFile>
-                            </configuration>
-                        </plugin>
-                    </reportPlugins>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.glassfish.build</groupId>
-                <artifactId>gfnexus-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 
@@ -524,75 +510,27 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.20</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <aggregate>true</aggregate>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>${findbugs.version}</version>
+                <configuration>
+                    <skip>${findbugs.skip}</skip>
+                    <threshold>${findbugs.threshold}</threshold>
+                    <excludeFilterFile>
+                        ${findbugs.common},${findbugs.exclude}
+                    </excludeFilterFile>
                 </configuration>
             </plugin>
         </plugins>
     </reporting>
 
     <profiles>
-
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.0-M1</version>
-                        <configuration>
-                           <additionalparam>-Xdoclint:none</additionalparam>
-                           <failOnError>true</failOnError>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>gf-internal-release</id>
-            <distributionManagement>
-                <repository>
-                    <uniqueVersion>false</uniqueVersion>
-                    <id>gf-internal-release</id>
-                    <url>http://gf-maven.us.oracle.com/nexus/content/repositories/gf-internal-release</url>
-                </repository>
-            </distributionManagement>
-        </profile>
-
         <profile>
             <id>coverage</id>
             <activation>
@@ -711,28 +649,10 @@
         </profile>
     </profiles>
 
-    <!-- TODO: Remove after dependencies will be updated to not rely on java.net. -->
-    <repositories>
-        <repository>
-            <id>releases.java.net</id>
-            <url>https://maven.java.net/content/repositories/releases/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
-            <id>jvnet-nexus-staging</id>
-            <url>https://maven.java.net/content/repositories/staging/</url>
-            <layout>default</layout>
-        </repository>
-        <repository>
-            <id>eclipse</id>
-            <url>http://download.eclipse.org/rt/eclipselink/maven.repo/</url>
-        </repository>
-    </repositories>
-
     <properties>
         <release.repository.url>https://maven.java.net/content/repositories/releases/</release.repository.url>
 
-        <istack.plugins.version>3.0.5</istack.plugins.version>
+        <istack.plugins.version>3.0.8</istack.plugins.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
@@ -751,31 +671,17 @@
         <findbugs.version>2.5.2</findbugs.version>
 
         <mf.dir>${project.build.outputDirectory}</mf.dir>
-
+        <legal.doc.source>${maven.multiModuleProjectDirectory}/..</legal.doc.source>
         <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-
-            <!-- provided dependencies -->
-            <dependency>
-                <groupId>com.sun.enterprise</groupId>
-                <artifactId>hk2</artifactId>
-                <version>1.6.3</version>
-                <scope>provided</scope>
-            </dependency>
-
             <!-- required dependencies -->
             <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.ejb</artifactId>
-                <version>3.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.gmbal</groupId>
-                <artifactId>gmbal</artifactId>
-                <version>${gmbal.version}</version>
+                <groupId>jakarta.ejb</groupId>
+                <artifactId>jakarta.ejb-api</artifactId>
+                <version>3.2.3</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.grizzly</groupId>
@@ -783,9 +689,9 @@
                 <version>1.0.40</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.registry</groupId>
-                <artifactId>javax.xml.registry-api</artifactId>
-                <version>1.0.4</version>
+                <groupId>jakarta.xml.registry</groupId>
+                <artifactId>jakarta.xml.registry-api</artifactId>
+                <version>1.0.9</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.registry</groupId>
@@ -793,29 +699,34 @@
                 <version>1.0.8</version>
             </dependency>
             <dependency>
-                <groupId>javax.xml.rpc</groupId>
-                <artifactId>javax.xml.rpc-api</artifactId>
-                <version>1.1</version>
+                <groupId>jakarta.xml.rpc</groupId>
+                <artifactId>jakarta.xml.rpc-api</artifactId>
+                <version>${xmlrpc-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.rpc</groupId>
                 <artifactId>jaxrpc-spi</artifactId>
-                <version>1.1.4_01</version>
+                <version>${xmlrpc-impl.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.rpc</groupId>
                 <artifactId>jaxrpc-impl</artifactId>
-                <version>1.1.4_01</version>
+                <version>${xmlrpc-impl.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.security.auth.message</groupId>
-                <artifactId>javax.security.auth.message-api</artifactId>
-                <version>1.1</version>
+                <groupId>jakarta.security.auth.message</groupId>
+                <artifactId>jakarta.security.auth.message-api</artifactId>
+                <version>1.1.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.santuario</groupId>
                 <artifactId>xmlsec</artifactId>
                 <version>${santuario.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons-logging.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.ws.security.kerb</groupId>

--- a/wsit/soaptcp/pom.xml
+++ b/wsit/soaptcp/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>soaptcp</artifactId>

--- a/wsit/soaptcp/soaptcp-api/pom.xml
+++ b/wsit/soaptcp/soaptcp-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>soaptcp</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>soaptcp-api</artifactId>
@@ -31,14 +31,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-maven-plugin</artifactId>
-                <inherited>true</inherited>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <inherited>true</inherited>
             </plugin>
         </plugins>
     </build>
@@ -55,8 +49,8 @@
             <artifactId>gmbal</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/soaptcp/soaptcp-impl/pom.xml
+++ b/wsit/soaptcp/soaptcp-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>soaptcp</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>soaptcp-impl</artifactId>
@@ -56,20 +56,20 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.jws</groupId>
-            <artifactId>javax.jws-api</artifactId>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
@@ -81,8 +81,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.stream.buffer</groupId>
@@ -101,8 +101,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/wsit/tests/coverage/pom.xml
+++ b/wsit/tests/coverage/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsit-tests</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/wsit/tests/e2e/pom.xml
+++ b/wsit/tests/e2e/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsit-tests</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wsit/tests/osgi-test/pom.xml
+++ b/wsit/tests/osgi-test/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/wsit/tests/pom.xml
+++ b/wsit/tests/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wsit-tests</artifactId>

--- a/wsit/ws-mex/pom.xml
+++ b/wsit/ws-mex/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>ws-mex</artifactId>
@@ -50,28 +50,28 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.stream.buffer</groupId>
@@ -81,8 +81,8 @@
 
         <!-- Provided scope -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+             <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/wsit/ws-rx/pom.xml
+++ b/wsit/ws-rx/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wsrx-project</artifactId>

--- a/wsit/ws-rx/wsmc-api/pom.xml
+++ b/wsit/ws-rx/wsmc-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
         <!--relativePath>../../pom.xml</relativePath-->
     </parent>
 
@@ -32,14 +32,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-maven-plugin</artifactId>
-                <inherited>true</inherited>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <inherited>true</inherited>
             </plugin>
         </plugins>
     </build>
@@ -55,8 +49,8 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/ws-rx/wsmc-impl/pom.xml
+++ b/wsit/ws-rx/wsmc-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wsmc-impl</artifactId>
@@ -54,16 +54,16 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
@@ -74,8 +74,8 @@
             <artifactId>policy</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
 
         <dependency>

--- a/wsit/ws-rx/wsrm-api/pom.xml
+++ b/wsit/ws-rx/wsrm-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
         <!--relativePath>../../pom.xml</relativePath-->
     </parent>
 
@@ -32,14 +32,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-maven-plugin</artifactId>
-                <inherited>true</inherited>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <inherited>true</inherited>
             </plugin>
         </plugins>
     </build>
@@ -51,8 +45,8 @@
             <artifactId>gmbal</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/ws-rx/wsrm-impl/pom.xml
+++ b/wsit/ws-rx/wsrm-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wsrm-impl</artifactId>
@@ -77,16 +77,16 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
@@ -97,8 +97,8 @@
             <artifactId>policy</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.stream.buffer</groupId>
@@ -109,8 +109,8 @@
             <artifactId>ha-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
         </dependency>
 
         <dependency>

--- a/wsit/ws-rx/wsrx-commons/pom.xml
+++ b/wsit/ws-rx/wsrx-commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wsrx-commons</artifactId>
@@ -54,16 +54,16 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/ws-rx/wsrx-testing/pom.xml
+++ b/wsit/ws-rx/wsrx-testing/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wsrx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wsrx-testing</artifactId>
@@ -31,14 +31,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-maven-plugin</artifactId>
-                <inherited>true</inherited>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <inherited>true</inherited>
             </plugin>
         </plugins>
     </build>
@@ -59,8 +53,8 @@
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/ws-sx/pom.xml
+++ b/wsit/ws-sx/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wssx-project</artifactId>

--- a/wsit/ws-sx/wssx-api/pom.xml
+++ b/wsit/ws-sx/wssx-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wssx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wssx-api</artifactId>
@@ -31,14 +31,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-maven-plugin</artifactId>
-                <inherited>true</inherited>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <inherited>true</inherited>
             </plugin>
         </plugins>
     </build>
@@ -54,12 +48,12 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/ws-sx/wssx-impl/pom.xml
+++ b/wsit/ws-sx/wssx-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wssx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wssx-impl</artifactId>
@@ -35,14 +35,11 @@
             <plugin>
                 <groupId>com.sun.istack</groupId>
                 <artifactId>istack-commons-maven-plugin</artifactId>
-                <inherited>true</inherited>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <inherited>true</inherited>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -50,6 +47,16 @@
                     <fork>true</fork>
                     <meminitial>128m</meminitial>
                     <maxmem>512m</maxmem>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>
+                        --add-exports java.security.jgss/sun.security.krb5=ALL-UNNAMED
+                        --add-exports java.xml/com.sun.org.apache.xerces.internal.impl.dv.util=ALL-UNNAMED
+                    </additionalOptions>
                 </configuration>
             </plugin>
         </plugins>
@@ -70,32 +77,32 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.rpc</groupId>
-            <artifactId>javax.xml.rpc-api</artifactId>
+            <groupId>jakarta.xml.rpc</groupId>
+            <artifactId>jakarta.xml.rpc-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.rpc</groupId>
             <artifactId>jaxrpc-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.security.auth.message</groupId>
-            <artifactId>javax.security.auth.message-api</artifactId>
+            <groupId>jakarta.security.auth.message</groupId>
+            <artifactId>jakarta.security.auth.message-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.santuario</groupId>
@@ -115,12 +122,12 @@
             <artifactId>policy</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>mail</artifactId>
+            <groupId>jakarta.mail</groupId>
+            <artifactId>jakarta.mail-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.messaging.saaj</groupId>
@@ -167,8 +174,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -196,44 +203,4 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-        <profile>
-            <id>release-9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>
-                                --add-modules java.activation
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <!-- <argLine>
-                               -add-modules java.activation
-                               -add-modules java.security.jgss
-                               -add-modules java.xml
-                            </argLine> -->
-                            <additionalJOptions>
-                                <additionalJOption>--add-modules</additionalJOption>
-                                <additionalJOption>java.activation</additionalJOption>
-                                <additionalJOption>--add-exports</additionalJOption>
-                                <additionalJOption>java.security.jgss/sun.security.krb5=ALL-UNNAMED</additionalJOption>
-                                <additionalJOption>--add-exports</additionalJOption>
-                                <additionalJOption>java.xml/com.sun.org.apache.xerces.internal.impl.dv.util=ALL-UNNAMED</additionalJOption>
-                            </additionalJOptions>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/ResolverId.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/ResolverId.java
@@ -23,7 +23,6 @@ import java.util.logging.Logger;
 import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 
-import org.apache.xml.security.utils.resolver.ResourceResolverContext;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -89,8 +88,6 @@ public class ResolverId extends ResourceResolverSpi {
     */
    public XMLSignatureInput engineResolve(Attr uri, String BaseURI)
            throws ResourceResolverException {
-
-      String uriToResolve = uri != null ? uri.getValue() : null;
       String uriNodeValue = uri.getNodeValue();
       if (MessageConstants.debug) {
           log.log(Level.FINEST, "uri = " + uriNodeValue);
@@ -119,14 +116,14 @@ public class ResolverId extends ResourceResolverSpi {
             log.log(Level.SEVERE,
                     LogStringsMessages.WSS_0603_XPATHAPI_TRANSFORMER_EXCEPTION(e.getMessage()),
                     e.getMessage());
-            throw new ResourceResolverException("empty", e, uriToResolve, BaseURI);
+            throw new ResourceResolverException("empty", e, uri, BaseURI);
          }
       }
 
       if (selectedElem == null) {
           log.log(Level.SEVERE,
                   LogStringsMessages.WSS_0604_CANNOT_FIND_ELEMENT());
-          throw new ResourceResolverException("empty", uriToResolve, BaseURI);
+          throw new ResourceResolverException("empty", uri, BaseURI);
       }
       Set resultSet = dereferenceSameDocumentURI(selectedElem);
       XMLSignatureInput result = new XMLSignatureInput(resultSet);
@@ -360,15 +357,5 @@ public class ResolverId extends ResourceResolverSpi {
 		nodeSet.add(node);
 	}
    }
-
-    @Override
-    public XMLSignatureInput engineResolveURI(ResourceResolverContext context) throws ResourceResolverException {
-        return engineResolve(context.attr, context.baseUri);
-    }
-
-    @Override
-    public boolean engineCanResolveURI(ResourceResolverContext context) {
-        return engineCanResolve(context.attr, context.baseUri);
-    }
 }
 

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/URIResolver.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/resolver/URIResolver.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.xml.security.utils.resolver.ResourceResolverContext;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Node;
 import org.w3c.dom.Element;
@@ -92,16 +91,6 @@ public class URIResolver extends ResourceResolverSpi {
         this.soapMsg = soapMsg;
     }
 
-    @Override
-    public XMLSignatureInput engineResolveURI(ResourceResolverContext context) throws ResourceResolverException {
-        return engineResolve(context.attr, context.baseUri);
-    }
-
-    @Override
-    public boolean engineCanResolveURI(ResourceResolverContext context) {
-        return engineCanResolve(context.attr, context.baseUri);
-    }
-
    public void setSOAPMessage(SOAPMessage soapMsg) {
         this.soapMsg = soapMsg;
    }
@@ -145,7 +134,7 @@ public class URIResolver extends ResourceResolverSpi {
                   try { 
                      result = _resolveClocation(uri, baseURI);
                   } catch (URIResolverException ure) {
-                     result = ResourceResolver.getInstance(uri, baseURI, false).resolve(uri, baseURI, false);
+                     result = ResourceResolver.getInstance(uri, baseURI).resolve(uri, baseURI);
                   }
                   break; 
           default:
@@ -160,8 +149,6 @@ public class URIResolver extends ResourceResolverSpi {
 
       XMLSignatureInput result = null;
 
-      String uriToResolve = uri != null ? uri.getValue() : null;
- 
       String uriNodeValue = uri.getNodeValue();
       Document doc = uri.getOwnerDocument();
 
@@ -178,14 +165,14 @@ public class URIResolver extends ResourceResolverSpi {
             log.log(Level.SEVERE,
                     LogStringsMessages.WSS_0603_XPATHAPI_TRANSFORMER_EXCEPTION(e.getMessage()),
                     e.getMessage());
-            throw new ResourceResolverException("empty", e, uriToResolve, baseUri);
+            throw new ResourceResolverException("empty", e, uri, baseUri);
          }
       }
 
       if (selectedElem == null) {
           log.log(Level.SEVERE,
                    LogStringsMessages.WSS_0604_CANNOT_FIND_ELEMENT());
-          throw new ResourceResolverException("empty", uriToResolve, baseUri);
+          throw new ResourceResolverException("empty", uri, baseUri);
       }
 
       Set resultSet = prepareNodeSet(selectedElem);
@@ -214,7 +201,6 @@ public class URIResolver extends ResourceResolverSpi {
    private XMLSignatureInput _resolveCid(Attr uri, String baseUri) 
                 throws ResourceResolverException {
 
-      String uriToResolve = uri != null ? uri.getValue() : null;
       XMLSignatureInput result = null;
       String uriNodeValue = uri.getNodeValue();
 
@@ -225,7 +211,7 @@ public class URIResolver extends ResourceResolverSpi {
               ((SecurableSoapMessage)soapMsg).getAttachmentPart(uriNodeValue);
          if (_part == null) {
              // log
-             throw new ResourceResolverException("empty", uriToResolve, baseUri);
+             throw new ResourceResolverException("empty", uri, baseUri);
          } 
          Object[] obj = AttachmentSignatureInput._getSignatureInput(_part); 
          result = new AttachmentSignatureInput((byte[])obj[1]);
@@ -233,7 +219,7 @@ public class URIResolver extends ResourceResolverSpi {
          ((AttachmentSignatureInput)result).setContentType(_part.getContentType()); 
       } catch (Exception e) {
          // log
-         throw new ResourceResolverException("empty", e, uriToResolve, baseUri);
+         throw new ResourceResolverException("empty", e, uri, baseUri);
       }
 
       try {
@@ -247,14 +233,13 @@ public class URIResolver extends ResourceResolverSpi {
 
    private XMLSignatureInput _resolveClocation(Attr uri, String baseUri) 
                 throws ResourceResolverException, URIResolverException {
-      String uriToResolve = uri != null ? uri.getValue() : null;
       URI uriNew = null;
       XMLSignatureInput result = null; 
       try {
          uriNew = getNewURI(uri.getNodeValue(), baseUri);
       } catch (URI.MalformedURIException ex) {
          // log          
-         throw new ResourceResolverException("empty", ex, uriToResolve, baseUri);
+         throw new ResourceResolverException("empty", ex, uri, baseUri);
       }
 
       if (soapMsg == null) throw generateException(uri, baseUri, errors[1]);
@@ -270,13 +255,13 @@ public class URIResolver extends ResourceResolverSpi {
          ((AttachmentSignatureInput)result).setMimeHeaders((Vector)obj[0]);
          ((AttachmentSignatureInput)result).setContentType(_part.getContentType()); 
       } catch (XWSSecurityException e) {
-         throw new ResourceResolverException("empty", e, uriToResolve, baseUri);
+         throw new ResourceResolverException("empty", e, uri, baseUri);
       } catch (SOAPException spe) {
          // log
-         throw new ResourceResolverException("empty", spe, uriToResolve, baseUri);
+         throw new ResourceResolverException("empty", spe, uri, baseUri);
       } catch (java.io.IOException ioe) {
          // log
-         throw new ResourceResolverException("empty", ioe, uriToResolve, baseUri);
+         throw new ResourceResolverException("empty", ioe, uri, baseUri);
       }
 
 
@@ -473,9 +458,8 @@ public class URIResolver extends ResourceResolverSpi {
     }
 
     private ResourceResolverException generateException(Attr uri, String baseUri, String error) {
-        String uriToResolve = uri != null ? uri.getValue() : null;
         XWSSecurityException xwssE = new XWSSecurityException(error);
-        return new ResourceResolverException("empty", xwssE, uriToResolve, baseUri);
+        return new ResourceResolverException("empty", xwssE, uri, baseUri);
     }
 
    /**

--- a/wsit/ws-tx/pom.xml
+++ b/wsit/ws-tx/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wstx-project</artifactId>

--- a/wsit/ws-tx/wstx-api/pom.xml
+++ b/wsit/ws-tx/wstx-api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wstx-api</artifactId>
@@ -30,25 +30,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-maven-plugin</artifactId>
-                <inherited>true</inherited>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -64,8 +45,8 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>

--- a/wsit/ws-tx/wstx-core/pom.xml
+++ b/wsit/ws-tx/wstx-core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wstx-core</artifactId>

--- a/wsit/ws-tx/wstx-impl/pom.xml
+++ b/wsit/ws-tx/wstx-impl/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wstx-impl</artifactId>
@@ -43,43 +43,21 @@
         </plugins>
     </build>
 
-    <profiles>
-       <profile>
-          <id>release-9</id>
-           <activation>
-               <jdk>[9,)</jdk>
-           </activation>
-           <build>
-             <plugins>
-               <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-surefire-plugin</artifactId>
-                 <configuration>
-                    <argLine>
-                       --add-modules java.activation
-                    </argLine>
-                 </configuration>
-              </plugin>
-             </plugins>
-           </build>
-         </profile>
-     </profiles>
-
     <dependencies>
         <!-- Provided scope -->
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.ejb</artifactId>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>javax.transaction-api</artifactId>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.resource</groupId>
-            <artifactId>connector-api</artifactId>
+            <groupId>jakarta.resource</groupId>
+            <artifactId>jakarta.resource-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -105,36 +83,36 @@
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.jws</groupId>
-            <artifactId>javax.jws-api</artifactId>
+            <groupId>jakarta.jws</groupId>
+            <artifactId>jakarta.jws-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>policy</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.xml.soap</groupId>
-            <artifactId>javax.xml.soap-api</artifactId>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
         </dependency>
 
         <!-- Test scope -->

--- a/wsit/ws-tx/wstx-services/pom.xml
+++ b/wsit/ws-tx/wstx-services/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>wstx-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>wstx-services</artifactId>

--- a/wsit/xmlfilter/pom.xml
+++ b/wsit/xmlfilter/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.glassfish.metro</groupId>
         <artifactId>metro-project</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>xmlfilter</artifactId>
@@ -61,8 +61,8 @@
             <artifactId>streambuffer</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <!-- Test scope -->


### PR DESCRIPTION
JDK 11 is required for build, 8 for run after this change

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>