### PR TITLE
Avoid redundant empty default namespace declaration if not forced.

### DIFF
--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/c14n/StAXEXC14nCanonicalizerImpl.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/impl/c14n/StAXEXC14nCanonicalizerImpl.java
@@ -101,6 +101,18 @@ public class StAXEXC14nCanonicalizerImpl extends StAXC14nCanonicalizerImpl  {
         this.forceDefNS = isForce;
     }
     public void writeNamespace(String prefix, String namespaceURI) throws XMLStreamException {
+        if(prefix == null || prefix.length() == 0){
+            String defNS = exC14NContext.getNamespaceURI(prefix);
+            if((defNS == null || defNS.length()== 0) && (namespaceURI == null || namespaceURI.length() ==0)){
+                if(!forceDefNS)
+                    return;
+            }
+            if(namespaceURI == null){
+                namespaceURI = "";
+            }
+            _defURI = namespaceURI;
+            prefix = "";
+        }
         exC14NContext.declareNamespace(prefix,namespaceURI);
     }
 


### PR DESCRIPTION
Signed-off-by: Roman Grigoriadi <roman.grigoriadi@oracle.com>