### PR TITLE
Signature alg fix

### DIFF
--- a/wsit/boms/bom-gf/pom.xml
+++ b/wsit/boms/bom-gf/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2025 Contributors to the Eclipse Foundation.
+    Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2013, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the

--- a/wsit/ws-sx/wssx-api/src/main/java/com/sun/xml/ws/api/security/trust/client/STSIssuedTokenConfiguration.java
+++ b/wsit/ws-sx/wssx-api/src/main/java/com/sun/xml/ws/api/security/trust/client/STSIssuedTokenConfiguration.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2020, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -35,6 +36,7 @@ public abstract class STSIssuedTokenConfiguration implements IssuedTokenConfigur
     public static final String STS_SERVICE_NAME ="sts-service-name";
     public static final String STS_PORT_NAME ="sts-port-name";
     public static final String STS_NAMESPACE ="sts-namespace";
+    public static final String STS_SIGNATURE_ALGORITHM ="sts-signature-algorithm";
     public static final String LIFE_TIME = "LifeTime";
     public static final String MAX_CLOCK_SKEW = "MaxClockSkew";
 

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/ws/security/trust/impl/TrustPluginImpl.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/ws/security/trust/impl/TrustPluginImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2020, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -540,6 +541,7 @@ public class TrustPluginImpl implements TrustPlugin {
         }
         dispatch.getRequestContext().put(WSTrustConstants.IS_TRUST_MESSAGE, "true");
         dispatch.getRequestContext().put(WSTrustConstants.TRUST_ACTION, getAction(wstVer, request.getRequestType().toString()));
+        dispatch.getRequestContext().put(STSIssuedTokenConfiguration.STS_SIGNATURE_ALGORITHM, stsConfig.getSignatureAlgorithm());
 
         // Pass the keys and/or username, password to the message context
 //        String userName = (String) stsConfig.getOtherOptions().get(com.sun.xml.wss.XWSSConstants.USERNAME_PROPERTY);

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityClientTube.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityClientTube.java
@@ -255,7 +255,7 @@ public class SecurityClientTube extends SecurityTubeBase implements SecureConver
         ((ProcessingContextImpl) ctx).setSCPolicyIDtoSctIdMap(scPolicyIDtoSctIdMap);
         String sigAlg = (String)(packet.invocationProperties.get("sts-signature-algorithm"));
         if(sigAlg!=null && (!sigAlg.equals(""))) {
-            ((ProcessingContextImpl) ctx).getAlgorithmSuite().setSignatureAlgorithm((String) (packet.invocationProperties.get("signature-algorithm")));
+            ((ProcessingContextImpl) ctx).getAlgorithmSuite().setSignatureAlgorithm(sigAlg);
         }
         ctx.isClient(true);
         try {

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityClientTube.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityClientTube.java
@@ -253,6 +253,10 @@ public class SecurityClientTube extends SecurityTubeBase implements SecureConver
         ProcessingContext ctx = initializeOutgoingProcessingContext(packet, isSCMessage);
         ((ProcessingContextImpl) ctx).setIssuedTokenContextMap(issuedTokenContextMap);
         ((ProcessingContextImpl) ctx).setSCPolicyIDtoSctIdMap(scPolicyIDtoSctIdMap);
+        String sigAlg = (String)(packet.invocationProperties.get("sts-signature-algorithm"));
+        if(sigAlg!=null && (!sigAlg.equals(""))) {
+            ((ProcessingContextImpl) ctx).getAlgorithmSuite().setSignatureAlgorithm((String) (packet.invocationProperties.get("signature-algorithm")));
+        }
         ctx.isClient(true);
         try {
             if (hasKerberosTokenPolicy()) {

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityClientTube.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityClientTube.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2020, 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -253,8 +254,8 @@ public class SecurityClientTube extends SecurityTubeBase implements SecureConver
         ProcessingContext ctx = initializeOutgoingProcessingContext(packet, isSCMessage);
         ((ProcessingContextImpl) ctx).setIssuedTokenContextMap(issuedTokenContextMap);
         ((ProcessingContextImpl) ctx).setSCPolicyIDtoSctIdMap(scPolicyIDtoSctIdMap);
-        String sigAlg = (String)(packet.invocationProperties.get("sts-signature-algorithm"));
-        if(sigAlg!=null && (!sigAlg.equals(""))) {
+        String sigAlg = (String)(packet.invocationProperties.get(STSIssuedTokenConfiguration.STS_SIGNATURE_ALGORITHM));
+        if (sigAlg != null && !sigAlg.isEmpty()) {
             ((ProcessingContextImpl) ctx).getAlgorithmSuite().setSignatureAlgorithm(sigAlg);
         }
         ctx.isClient(true);


### PR DESCRIPTION
There doesn't appear to be any way for the setSignatureAlgorithm(...) in com.sun.xml.ws.security.trust.impl.client.DefaultSTSIssuedTokenConfiguration to actually set/override the signature algorithm for STS requests, instead it's always reset to null and thus defaults to SHA1.

This patch allows the setting to pass through to the context and sets the signature algorithm in the algorithm suite. I'm unclear on how the internals of the API are intended to set/pass through this value, if this is not correct then I'm happy to discuss. 

There appears to also be an issue with WSDL set signature algorithms not addressed here, they don't seem to actually show up in requests or while debugging the request creation (Please refer to https://github.com/eclipse-ee4j/metro-wsit/issues/57)