### PR TITLE
Make jakarta.xml.bind.* resolution optional

### DIFF
--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -243,7 +243,7 @@
                             jakarta.jws.soap;version=${jaxws-api.osgiVersion},
                             jakarta.xml.soap.*;version=${saaj-api.osgiVersion},
                             jakarta.xml.ws.*;version=${jaxws-api.osgiVersion},
-                            jakarta.xml.bind.*;version=${jaxb-api.osgiVersion},
+                            jakarta.xml.bind.*;resolution:=optional,
                             org.apache.coyote;resolution:=optional,
                             org.apache.tomcat.util.buf;resolution:=optional,
                             org.jvnet.mimepull;resolution:=optional,


### PR DESCRIPTION
Signed-off-by: Gaurav Gupta <gaurav.gupta@payara.fish>

Fixes following OSGi error on Glassfish startup:

````
Caused by: org.osgi.framework.BundleException: 
Unable to resolve org.glassfish.main.security.webservices.security [279](R 279.0): 
missing requirement [org.glassfish.main.security.webservices.security [279](R 279.0)] 
osgi.wiring.package; (&(osgi.wiring.package=com.sun.xml.ws.api.message)(version>=3.0.0)(!(version>=4.0.0))) 
	[
	caused by: Unable to resolve org.glassfish.metro.webservices-osgi [278](R 278.0): 
	missing requirement [org.glassfish.metro.webservices-osgi [278](R 278.0)] 
	osgi.wiring.package; (&(osgi.wiring.package=jakarta.xml.bind)(version>=3.0.0.RC3))
	]
Unresolved requirements: [
[org.glassfish.main.security.webservices.security [279](R 279.0)] 
osgi.wiring.package; (&(osgi.wiring.package=com.sun.xml.ws.api.message)(version>=3.0.0)(!(version>=4.0.0)))
]
````