### PR TITLE
WSATRecoveryEventListener should not be static class

### DIFF
--- a/wsit/ws-tx/wstx-api/src/main/java/com/sun/xml/ws/tx/dev/WSATRuntimeConfig.java
+++ b/wsit/ws-tx/wstx-api/src/main/java/com/sun/xml/ws/tx/dev/WSATRuntimeConfig.java
@@ -207,7 +207,8 @@ public final class WSATRuntimeConfig {
         void afterRecovery(boolean success, boolean delegated, String instance);
     }
 
-    public static class WSATRecoveryEventListener implements RecoveryEventListener {
+    //do NOT make this static
+    public class WSATRecoveryEventListener implements RecoveryEventListener {
 
         @Override
         public void beforeRecovery(boolean delegated, String instance) {


### PR DESCRIPTION
Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>