### PR TITLE
Upgraded authentication-api to 3.0.0-RC2

### DIFF
--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -28,7 +28,7 @@
     <description>Metro Web Services Stack Dependency POM for Metro-CS</description>
 
     <properties>
-        <authentication-api.version>2.0.0</authentication-api.version>
+        <authentication-api.version>3.0.0-RC2</authentication-api.version>
         <connector-api.version>2.1.0-RC1</connector-api.version>
         <ejb-api.version>4.0.0</ejb-api.version>
         <transaction-api.version>2.0.1-RC1</transaction-api.version>

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/RealmAuthenticationAdapter.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/RealmAuthenticationAdapter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -24,13 +25,10 @@ import javax.security.auth.Subject;
  * The SPI implementation class needs to 
  * specified as a META-INF/services entry with name "com.sun.xml.xwss.RealmAuthenticator". 
  * A default implementation of this SPI is returned if no entry is configured.
- *
- * 
  */
 public abstract class RealmAuthenticationAdapter {
 
     public static final String UsernameAuthenticator = "com.sun.xml.xwss.RealmAuthenticator";
-    private static final String SERVLET_CONTEXT_CLASSNAME = "jakarta.servlet.ServletContext";
     // Prefixing with META-INF/ instead of /META-INF/. /META-INF/ is working fine
     // when loading from a JAR file but not when loading from a plain directory.
     private static final String JAR_PREFIX = "META-INF/";

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ClientPipeCreator.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ClientPipeCreator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -34,7 +35,7 @@ public class ClientPipeCreator extends ClientPipelineHook {
     @Override
     public Pipe createSecurityPipe(PolicyMap map, 
             ClientPipeAssemblerContext ctxt, Pipe tail) {
-        HashMap<Object, Object> propBag = new HashMap<>();
+        HashMap<String, Object> propBag = new HashMap<>();
         propBag.put(PipeConstants.POLICY, map);
         propBag.put(PipeConstants.WSDL_MODEL, ctxt.getWsdlModel());
         propBag.put(PipeConstants.SERVICE, ctxt.getService());
@@ -50,7 +51,7 @@ public class ClientPipeCreator extends ClientPipelineHook {
     
     @Override
     public @NotNull Tube createSecurityTube(ClientTubelineAssemblyContext context) {
-        HashMap<Object, Object> propBag = new HashMap<>();
+        HashMap<String, Object> propBag = new HashMap<>();
         propBag.put(PipeConstants.POLICY, context.getPolicyMap());
         propBag.put(PipeConstants.WSDL_MODEL, context.getWrappedContext().getWsdlModel());
         propBag.put(PipeConstants.SERVICE, context.getService());

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ClientSecurityPipe.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ClientSecurityPipe.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -47,7 +48,7 @@ public class ClientSecurityPipe extends AbstractFilterPipeImpl
             LogDomainConstants.WSIT_PVD_DOMAIN,
             LogDomainConstants.WSIT_PVD_DOMAIN_BUNDLE);
 
-    public ClientSecurityPipe(Map<Object, Object> props, Pipe next) {
+    public ClientSecurityPipe(Map<String, Object> props, Pipe next) {
 
         super(next);
 	props.put(PipeConstants.SECURITY_PIPE,this);
@@ -218,7 +219,7 @@ public class ClientSecurityPipe extends AbstractFilterPipeImpl
 
 	    // put MessageInfo in properties map, since MessageInfo 
 	    // is not passed to getAuthContext, key idicates function
-	    HashMap<Object, Object> map = new HashMap<>();
+	    HashMap<String, Object> map = new HashMap<>();
 	    map.put(PipeConstants.SECURITY_TOKEN,info);
 
 	    helper.getSessionToken(map,info,clientSubject);

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ClientSecurityTube.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ClientSecurityTube.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -60,7 +61,7 @@ public class ClientSecurityTube extends AbstractFilterTubeImpl implements Secure
         super(nextTube);  
     }
     
-    public ClientSecurityTube(Map<Object, Object> props, Tube next) {
+    public ClientSecurityTube(Map<String, Object> props, Tube next) {
 
         super(next);
         props.put(PipeConstants.SECURITY_PIPE, this);
@@ -249,7 +250,7 @@ public class ClientSecurityTube extends AbstractFilterTubeImpl implements Secure
 	    Subject clientSubject = getClientSubject(packet);
 	    // put MessageInfo in properties map, since MessageInfo 
 	    // is not passed to getAuthContext, key idicates function
-	    HashMap<Object, Object> map = new HashMap<>();
+	    HashMap<String, Object> map = new HashMap<>();
 	    map.put(PipeConstants.SECURITY_TOKEN,info);
 	    helper.getSessionToken(map,info,clientSubject);
 	    // helper returns token in map of msgInfo, using same key

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ConfigHelper.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ConfigHelper.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -61,12 +62,12 @@ public abstract class ConfigHelper /*implements RegistrationListener*/ {
 	
     protected String layer;
     protected String appCtxt;
-    protected Map<Object, Object> map;
+    protected Map<String, Object> map;
     protected CallbackHandler cbh;
     protected AuthConfigRegistrationWrapper listenerWrapper = null;
 
     protected void init(String layer, String appContext,
-            Map<Object, Object> map, CallbackHandler cbh) {
+            Map<String, Object> map, CallbackHandler cbh) {
 
         factory = AuthConfigFactory.getFactory();
 	this.layer = layer;

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/PipeHelper.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/PipeHelper.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -58,7 +59,7 @@ public class PipeHelper extends ConfigHelper {
     private Class secCntxt = null;
     private SecurityContext context = null;
     
-    public PipeHelper(String layer, Map<Object, Object> map, CallbackHandler cbh) {
+    public PipeHelper(String layer, Map<String, Object> map, CallbackHandler cbh) {
         init(layer, getAppCtxt(map), map, cbh);
 
 	this.seiModel = (SEIModel) map.get(PipeConstants.SEI_MODEL);
@@ -146,7 +147,7 @@ public class PipeHelper extends ConfigHelper {
         return s;
     }
 
-    public void getSessionToken(Map<Object, Object> m, 
+    public void getSessionToken(Map<String, Object> m,
 				MessageInfo info, 
 				Subject s) throws AuthException {
 	ClientAuthConfig c = (ClientAuthConfig) getAuthConfig(false);    
@@ -218,10 +219,9 @@ public class PipeHelper extends ConfigHelper {
     }
     
     
-    private static String getAppCtxt(Map map) {
+    private static String getAppCtxt(Map<String, Object> map) {
         String rvalue = null;
-        WSEndpoint wse = 
-            (WSEndpoint) map.get(PipeConstants.ENDPOINT);
+        WSEndpoint wse = (WSEndpoint) map.get(PipeConstants.ENDPOINT);
         Container container = (Container)map.get(PipeConstants.CONTAINER);
         // endpoint
         if (wse != null) {
@@ -253,7 +253,7 @@ public class PipeHelper extends ConfigHelper {
     }
 
     @SuppressWarnings("unchecked")
-    private static void addModel(MessageInfo info, Map<Object, Object> map) {
+    private static void addModel(MessageInfo info, Map<String, Object> map) {
         Object model = map.get(PipeConstants.WSDL_MODEL);
         if (model != null) {
             info.getMap().put(PipeConstants.WSDL_MODEL,model);

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/SAMAuthConfig.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/SAMAuthConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.xml.wss.provider.wsit;
+
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.config.ServerAuthConfig;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.module.ServerAuthModule;
+
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+
+
+/**
+ * Required wrapper for custom {@link ServerAuthModule}
+ *
+ * @author David Matejcek
+ */
+public class SAMAuthConfig implements ServerAuthConfig {
+
+    private final String layer;
+    private final String appContext;
+    private final CallbackHandler handler;
+    private final ServerAuthModule serverAuthModule;
+
+
+    /**
+     * @param layer - usually SOAP or HttpServlet
+     * @param appContext
+     * @param handler
+     * @param serverAuthModule
+     */
+    public SAMAuthConfig(String layer, String appContext, CallbackHandler handler, ServerAuthModule serverAuthModule) {
+        this.layer = layer;
+        this.appContext = appContext;
+        this.handler = handler;
+        this.serverAuthModule = serverAuthModule;
+    }
+
+
+    @Override
+    public String getMessageLayer() {
+        return layer;
+    }
+
+
+    @Override
+    public String getAppContext() {
+        return appContext;
+    }
+
+
+    @Override
+    public String getAuthContextID(MessageInfo messageInfo) {
+        return appContext;
+    }
+
+
+    @Override
+    public void refresh() {
+    }
+
+
+    @Override
+    public boolean isProtected() {
+        return false;
+    }
+
+
+    @Override
+    public ServerAuthContext getAuthContext(String authContextID, Subject serviceSubject,
+        Map<String, Object> properties) throws AuthException {
+        return new SAMAuthContext(handler, serverAuthModule);
+    }
+}

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/SAMAuthContext.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/SAMAuthContext.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.xml.wss.provider.wsit;
+
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.AuthStatus;
+import jakarta.security.auth.message.MessageInfo;
+import jakarta.security.auth.message.config.ServerAuthContext;
+import jakarta.security.auth.message.module.ServerAuthModule;
+
+import java.util.Collections;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+
+
+/**
+ * Required wrapper for custom {@link ServerAuthModule}
+ *
+ * @author David Matejcek
+ */
+public class SAMAuthContext implements ServerAuthContext {
+
+    private final ServerAuthModule serverAuthModule;
+
+    /**
+     * Creates instance of this class and calls
+     * {@link ServerAuthModule#initialize(jakarta.security.auth.message.MessagePolicy, jakarta.security.auth.message.MessagePolicy, CallbackHandler, java.util.Map)}
+     *
+     * @param handler
+     * @param serverAuthModule
+     * @throws AuthException
+     */
+    public SAMAuthContext(final CallbackHandler handler, final ServerAuthModule serverAuthModule) throws AuthException {
+        this.serverAuthModule = serverAuthModule;
+        this.serverAuthModule.initialize(null, null, handler, Collections.<String, Object> emptyMap());
+    }
+
+
+    @Override
+    public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject)
+        throws AuthException {
+        return serverAuthModule.secureResponse(messageInfo, serviceSubject);
+    }
+
+
+    @Override
+    public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
+        serverAuthModule.cleanSubject(messageInfo, subject);
+    }
+}

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/SAMConfigProvider.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/SAMConfigProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.xml.wss.provider.wsit;
+
+import jakarta.security.auth.message.AuthException;
+import jakarta.security.auth.message.config.AuthConfigProvider;
+import jakarta.security.auth.message.config.ClientAuthConfig;
+import jakarta.security.auth.message.config.ServerAuthConfig;
+import jakarta.security.auth.message.module.ServerAuthModule;
+
+import javax.security.auth.callback.CallbackHandler;
+
+
+/**
+ * Required wrapper for custom {@link ServerAuthModule}.
+ *
+ * @author David Matejcek
+ */
+public class SAMConfigProvider implements AuthConfigProvider {
+
+    private final ServerAuthModule serverAuthModule;
+
+
+    /**
+     * @param serverAuthModule - this module does all the authentication,
+     */
+    public SAMConfigProvider(final ServerAuthModule serverAuthModule) {
+        this.serverAuthModule = serverAuthModule;
+    }
+
+    @Override
+    public ClientAuthConfig getClientAuthConfig(String layer, String appContext, CallbackHandler handler)
+        throws AuthException {
+        return null;
+    }
+
+
+    @Override
+    public ServerAuthConfig getServerAuthConfig(String layer, String appContext, CallbackHandler handler)
+        throws AuthException {
+        return new SAMAuthConfig(layer, appContext, handler, this.serverAuthModule);
+    }
+
+
+    @Override
+    public void refresh() {
+    }
+}

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/SecurityTubeFactory.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/SecurityTubeFactory.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -16,7 +17,6 @@ import com.sun.xml.ws.api.model.wsdl.WSDLBoundOperation;
 import com.sun.xml.ws.api.model.wsdl.WSDLPort;
 import com.sun.xml.ws.api.pipe.*;
 import com.sun.xml.ws.api.pipe.helper.PipeAdapter;
-import com.sun.xml.ws.api.server.Container;
 import com.sun.xml.ws.api.server.WSEndpoint;
 import com.sun.xml.ws.assembler.dev.ClientTubelineAssemblyContext;
 import com.sun.xml.ws.assembler.dev.ServerTubelineAssemblyContext;
@@ -45,7 +45,6 @@ import com.sun.xml.wss.impl.misc.SecurityUtil;
 import com.sun.xml.wss.jaxws.impl.SecurityClientTube;
 import com.sun.xml.wss.jaxws.impl.SecurityServerTube;
 import com.sun.xml.wss.provider.wsit.logging.LogDomainConstants;
-import com.sun.xml.wss.provider.wsit.logging.LogStringsMessages;
 import com.sun.xml.xwss.XWSSClientTube;
 import com.sun.xml.xwss.XWSSServerTube;
 
@@ -71,7 +70,6 @@ public final class SecurityTubeFactory implements TubeFactory, TubelineAssemblyC
         LogDomainConstants.WSIT_PVD_DOMAIN,
         LogDomainConstants.WSIT_PVD_DOMAIN_BUNDLE);
 
-    private static final String SERVLET_CONTEXT_CLASSNAME = "jakarta.servlet.ServletContext";
     //Added for Security Pipe Unification with JSR 196 on GlassFish
     private static final String ENDPOINT = "ENDPOINT";
     private static final String NEXT_PIPE = "NEXT_PIPE";
@@ -89,8 +87,8 @@ public final class SecurityTubeFactory implements TubeFactory, TubelineAssemblyC
        if(maxNonceAge == MessageConstants.MAX_NONCE_AGE){ //if max nonce age is not set in domain.xml
            String maxNAge = System.getProperty("MAX_NONCE_AGE");
            maxNonceAge = (maxNAge != null) ? Long.parseLong(maxNAge) : MessageConstants.MAX_NONCE_AGE ;
-       } 
-    }    
+       }
+    }
 
     @Override
     public void prepareContext(ClientTubelineAssemblyContext context) throws WebServiceException {
@@ -399,17 +397,7 @@ public final class SecurityTubeFactory implements TubeFactory, TubelineAssemblyC
         QName serviceQName = context.getEndpoint().getServiceName();
         //TODO: not sure which of the two above will give the service name as specified in DD
         String serviceLocalName = serviceQName.getLocalPart();
-        Container container = context.getEndpoint().getContainer();
-
-        Object ctxt = null;
-        if (container != null) {
-            try {
-                final Class<?> contextClass = Class.forName(SERVLET_CONTEXT_CLASSNAME);
-                ctxt = container.getSPI(contextClass);
-            } catch (ClassNotFoundException e) {
-                log.log(Level.WARNING, LogStringsMessages.WSITPVD_0066_SERVLET_CONTEXT_NOTFOUND(), e);
-            }
-        }
+        Object ctxt = SecurityUtil.getServletContext(context.getEndpoint());
         String serverName = "server";
         if (ctxt != null) {
 

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ServerPipeCreator.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ServerPipeCreator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -39,7 +40,7 @@ public class ServerPipeCreator extends ServerPipelineHook {
     public Pipe createSecurityPipe(PolicyMap map, SEIModel sei,
             WSDLPort port, WSEndpoint owner, Pipe tail) {
 
-        HashMap<Object, Object> props = new HashMap<>();
+        HashMap<String, Object> props = new HashMap<>();
 
         boolean httpBinding = BindingID.XML_HTTP.equals(owner.getBinding().getBindingId());
         props.put(PipeConstants.POLICY, map);
@@ -56,7 +57,7 @@ public class ServerPipeCreator extends ServerPipelineHook {
     @NotNull
     Tube createSecurityTube(ServerTubelineAssemblyContext context) {
 
-        HashMap<Object, Object> props = new HashMap<>();
+        HashMap<String, Object> props = new HashMap<>();
         boolean httpBinding = BindingID.XML_HTTP.equals(context.getEndpoint().getBinding().getBindingId());
         props.put(PipeConstants.POLICY, context.getPolicyMap());
         props.put(PipeConstants.SEI_MODEL, context.getSEIModel());

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ServerSecurityPipe.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ServerSecurityPipe.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -45,15 +46,14 @@ public class ServerSecurityPipe extends AbstractFilterPipeImpl {
 
     private PipeHelper helper;
 
-    public ServerSecurityPipe(Map<Object, Object> props, final Pipe next, 
-			     boolean isHttpBinding) {
+    public ServerSecurityPipe(Map<String, Object> props, final Pipe next, boolean isHttpBinding) {
         super(next);
-
-	props.put(PipeConstants.SECURITY_PIPE,this);
-	this.helper = new PipeHelper(PipeConstants.SOAP_LAYER,props,null);
+        props.put(PipeConstants.SECURITY_PIPE, this);
+        this.helper = new PipeHelper(PipeConstants.SOAP_LAYER, props, null);
         this.isHttpBinding = isHttpBinding;
-    }    
-    
+    }
+
+
     protected ServerSecurityPipe(ServerSecurityPipe that,
             PipeCloner cloner) {
 

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ServerSecurityTube.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/ServerSecurityTube.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -47,8 +48,8 @@ public class ServerSecurityTube extends AbstractFilterTubeImpl {
     private ServerAuthContext sAC = null;
     private PacketMessageInfo info = null;
     private WSEndpoint wsEndpoint = null;
-    @SuppressWarnings("unchecked")
-    public ServerSecurityTube(Map<Object, Object> props, final Tube next, boolean isHttpBinding) {
+
+    public ServerSecurityTube(Map<String, Object> props, final Tube next, boolean isHttpBinding) {
         super(next);
         props.put(PipeConstants.SECURITY_PIPE, this);
         this.helper = new PipeHelper(PipeConstants.SOAP_LAYER, props, null);
@@ -56,7 +57,6 @@ public class ServerSecurityTube extends AbstractFilterTubeImpl {
         this.wsEndpoint = (WSEndpoint) props.get(PipeConstants.ENDPOINT);
 
         //Registers IdentityComponent if either cs is not null        
-        
     }
 
     protected ServerSecurityTube(ServerSecurityTube that, TubeCloner cloner) {

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITAuthConfigProvider.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITAuthConfigProvider.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -56,7 +57,7 @@ public class WSITAuthConfigProvider implements AuthConfigProvider {
     private ReentrantReadWriteLock.WriteLock wLock;
     
     /** Creates a new instance of WSITAuthConfigProvider */
-    public WSITAuthConfigProvider(Map props, AuthConfigFactory factory) {
+    public WSITAuthConfigProvider(Map<String, String> props, AuthConfigFactory factory) {
         //properties = props;
         //this.factory = factory;
         if (factory != null) {

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITAuthContextBase.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITAuthContextBase.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -78,7 +79,6 @@ import com.sun.xml.ws.security.policy.Token;
 
 
 import jakarta.xml.bind.JAXBContext;
-//import jakarta.xml.bind.Unmarshaller;
 
 import com.sun.xml.wss.impl.MessageConstants;
 import com.sun.xml.wss.impl.misc.DefaultCallbackHandler;
@@ -89,7 +89,6 @@ import com.sun.xml.ws.security.policy.CallbackHandlerConfiguration;
 import com.sun.xml.ws.security.policy.Validator;
 import com.sun.xml.ws.security.policy.ValidatorConfiguration;
 import com.sun.xml.ws.security.policy.WSSAssertion;
-//import com.sun.xml.wss.impl.OperationResolver;
 
 import java.util.Properties;
 
@@ -274,7 +273,7 @@ public abstract class WSITAuthContextBase  {
     }    
     
     /** Creates a new instance of WSITAuthContextBase */
-    public WSITAuthContextBase(Map<Object, Object> map) {
+    public WSITAuthContextBase(Map<String, Object> map) {
         this.nextPipe = (Pipe)map.get("NEXT_PIPE");
         this.nextTube = (Tube)map.get("NEXT_TUBE");
         PolicyMap wsPolicyMap = (PolicyMap)map.get("POLICY");

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITClientAuthConfig.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITClientAuthConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -25,7 +26,6 @@ import com.sun.xml.ws.security.secconv.WSSecureConversationException;
 import java.util.Map;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
-import jakarta.security.auth.message.AuthException;
 import jakarta.security.auth.message.MessageInfo;
 import jakarta.security.auth.message.config.ClientAuthConfig;
 import jakarta.security.auth.message.config.ClientAuthContext;
@@ -69,9 +69,7 @@ public class WSITClientAuthConfig implements ClientAuthConfig {
     }
 
     @Override
-    public ClientAuthContext getAuthContext(String operation, Subject subject, Map rawMap) {
-        @SuppressWarnings("unchecked") Map<Object, Object> map = rawMap;
-
+    public ClientAuthContext getAuthContext(String operation, Subject subject, Map<String, Object> map) {
         PolicyMap pMap = (PolicyMap) map.get("POLICY");
         WSDLPort port = (WSDLPort) map.get("WSDL_MODEL");
         Object tubeOrPipe = map.get(PipeConstants.SECURITY_PIPE);
@@ -167,8 +165,7 @@ public class WSITClientAuthConfig implements ClientAuthConfig {
         return this.tubetoClientAuthContextHash.remove( hashCode);
     }
 
-    @SuppressWarnings("unchecked")
-    private JAXBElement startSecureConversation(Map map, WSITClientAuthContext clientAuthContext) {
+    private JAXBElement startSecureConversation(Map<String, Object> map, WSITClientAuthContext clientAuthContext) {
         //check if we need to start secure conversation
         JAXBElement ret = null;
         try {

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITClientAuthContext.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITClientAuthContext.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -50,7 +51,6 @@ import com.sun.xml.ws.security.opt.impl.JAXBFilterProcessingContext;
 import com.sun.xml.ws.security.policy.Token;
 import com.sun.xml.ws.security.policy.IssuedToken;
 import com.sun.xml.ws.security.policy.SecureConversationToken;
-import com.sun.xml.ws.security.secconv.WSSecureConversationException;
 import com.sun.xml.ws.security.secconv.impl.client.DefaultSCTokenConfiguration;
 import com.sun.xml.ws.security.trust.GenericToken;
 import com.sun.xml.ws.security.trust.STSIssuedTokenFeature;
@@ -150,7 +150,7 @@ public class WSITClientAuthContext extends WSITAuthContextBase
     
     /** Creates a new instance of WSITClientAuthContext */
     @SuppressWarnings("unchecked")
-    public WSITClientAuthContext(String operation, Subject subject, Map<Object, Object> map, CallbackHandler callbackHandler) {
+    public WSITClientAuthContext(String operation, Subject subject, Map<String, Object> map, CallbackHandler callbackHandler) {
         super(map);
         this.authConfig = new WeakReference<>((WSITClientAuthConfig) map.get(PipeConstants.AUTH_CONFIG));
         this.tubeOrPipeHashCode =(map.get(PipeConstants.SECURITY_PIPE)).hashCode();
@@ -253,8 +253,7 @@ public class WSITClientAuthContext extends WSITAuthContextBase
                 }
 
                 //set the isTrustProperty into MessageInfo
-                @SuppressWarnings("unchecked")
-                Map<Object, Object> msgInfoMap = messageInfo.getMap();
+                Map<String, Object> msgInfoMap = messageInfo.getMap();
                 msgInfoMap.put("IS_TRUST_MSG", Boolean.valueOf(isTrustMsg));
 
                 // keep the message

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITClientAuthModule.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITClientAuthModule.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -50,9 +51,7 @@ public class WSITClientAuthModule implements ClientAuthModule {
         LogDomainConstants.WSIT_PVD_DOMAIN,
         LogDomainConstants.WSIT_PVD_DOMAIN_BUNDLE);
     
-    private Class[] supported = new Class[2];
-    protected static final String DEBUG = "debug";
-    private boolean debug= false;
+    private final Class<?>[] supported = new Class[2];
     
     /** Creates a new instance of WSITClientAuthModule */
     public WSITClientAuthModule() {
@@ -64,9 +63,7 @@ public class WSITClientAuthModule implements ClientAuthModule {
     public void initialize(MessagePolicy requestPolicy,
                            MessagePolicy responsePolicy,
                            CallbackHandler handler,
-                           Map options) {
-        String bg = (String)options.get(DEBUG);
-        if (bg !=null && bg.equals("true")) debug = true;
+                           Map<String, Object> options) {
     }
 
     @Override

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITServerAuthConfig.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITServerAuthConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -23,7 +24,6 @@ import com.sun.xml.ws.policy.PolicyMap;
 import java.util.Map;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
-import jakarta.security.auth.message.AuthException;
 import jakarta.security.auth.message.MessageInfo;
 import jakarta.security.auth.message.config.ServerAuthConfig;
 import jakarta.security.auth.message.config.ServerAuthContext;
@@ -56,8 +56,7 @@ public class WSITServerAuthConfig implements ServerAuthConfig {
     }
 
     @Override
-    public ServerAuthContext getAuthContext(String operation, Subject subject, Map rawMap) {
-        @SuppressWarnings("unchecked") Map<Object, Object> map = rawMap;
+    public ServerAuthContext getAuthContext(String operation, Subject subject, Map<String, Object> map) {
         PolicyMap pMap = (PolicyMap) map.get("POLICY");
         WSDLPort port = (WSDLPort) map.get("WSDL_MODEL");
         if (pMap == null || pMap.isEmpty()) {

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITServerAuthModule.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/provider/wsit/WSITServerAuthModule.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -49,11 +50,8 @@ public class WSITServerAuthModule implements ServerAuthModule {
         Logger.getLogger(
         LogDomainConstants.WSIT_PVD_DOMAIN,
         LogDomainConstants.WSIT_PVD_DOMAIN_BUNDLE);
-    
-    Class[] supported = new Class[2];
-    boolean debug = false;
-    protected static final String DEBUG = "debug";
-    
+    private Class<?>[] supported = new Class[2];
+
     /** Creates a new instance of WSITServerAuthModule */
     public WSITServerAuthModule() {
         supported[0] = SOAPMessage.class;
@@ -61,17 +59,13 @@ public class WSITServerAuthModule implements ServerAuthModule {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public void initialize(MessagePolicy requestPolicy,
-	       MessagePolicy responsePolicy,
-	       CallbackHandler handler,
-	       Map options) {
-        String bg = (String)options.get(DEBUG);
-        if (bg !=null && bg.equals("true")) debug = true;
+    public void initialize(MessagePolicy requestPolicy, MessagePolicy responsePolicy, CallbackHandler handler,
+        Map<String, Object> options) {
     }
 
+
     @Override
-    public Class[] getSupportedMessageTypes() {
+    public Class<?>[] getSupportedMessageTypes() {
         return supported;
     }
 

--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/xwss/XWSSServerTube.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/xwss/XWSSServerTube.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -36,8 +37,6 @@ import com.sun.xml.wss.impl.config.DeclarativeSecurityConfiguration;
 import com.sun.xml.wss.impl.configuration.StaticApplicationContext;
 import com.sun.xml.wss.impl.misc.SecurityUtil;
 import com.sun.xml.wss.impl.policy.SecurityPolicy;
-import com.sun.xml.xwss.SecurityConfiguration;
-import com.sun.xml.ws.api.server.Container;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -80,7 +79,6 @@ public class XWSSServerTube extends AbstractFilterTubeImpl {
     protected static final String FALSE = "false";
     protected static final String CONTEXT_WSDL_OPERATION =
             "com.sun.xml.ws.wsdl.operation";
-    private static final String SERVLET_CONTEXT_CLASSNAME = "jakarta.servlet.ServletContext";
     
     /** Creates a new instance of XWSSServerPipe */
     public XWSSServerTube(WSEndpoint epoint, WSDLPort prt, Tube nextTube) {
@@ -139,19 +137,7 @@ public class XWSSServerTube extends AbstractFilterTubeImpl {
     private URL getServerConfig() {
         QName serviceQName = endPoint.getServiceName();
         String serviceName = serviceQName.getLocalPart();
-        
-        
-        Container container = endPoint.getContainer();
-        
-        Object ctxt = null;
-        if (container != null) {
-            try {
-                final Class<?> contextClass = Class.forName(SERVLET_CONTEXT_CLASSNAME);
-                ctxt = container.getSPI(contextClass);
-            } catch (ClassNotFoundException e) {
-                //log here at FINE Level : that the ServletContext was not found
-            }
-        }
+        Object ctxt = SecurityUtil.getServletContext(endPoint);
         String serverName = "server";
         URL url = null;
         if (ctxt != null) {


### PR DESCRIPTION
- to avoid copy and paste I moved loading the ServletContext to SecurityUtil
- generic maps were synced to implemented interfaces (usually `Map<Object, Object>` to `Map<String, Object>`)
- implemented new methods: registerServerAuthModule, removeServerAuthModule

Locally passed GlassFish tests including two which failed with 4.0.0-M3:
https://ci.eclipse.org/glassfish/job/glassfish_build-and-test-using-jenkinsfile/job/PR-23843/3/testReport/