### PR TITLE
Also set policy credentials for message level policies

### DIFF
--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityTubeBase.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityTubeBase.java
@@ -732,12 +732,26 @@ public abstract class SecurityTubeBase extends AbstractFilterTubeImpl {
             //This will be used for setting credentials like  spVersion... etc for binding level policies
             setPolicyCredentials(endpointPolicy);
 
-            //This will be used for setting credentials like  spVersion... etc for operation level policies
+            //This will be used for setting credentials like  spVersion... etc for operation and message level policies
             for (WSDLBoundOperation operation : tubeConfig.getWSDLPort().getBinding().getBindingOperations()) {
                 QName operationName = new QName(operation.getBoundPortType().getName().getNamespaceURI(), operation.getName().getLocalPart());
                 PolicyMapKey operationKey = PolicyMap.createWsdlOperationScopeKey(serviceName, portName, operationName);
                 Policy operationPolicy = wsPolicyMap.getOperationEffectivePolicy(operationKey);
                 setPolicyCredentials(operationPolicy);
+
+                PolicyMapKey messageKey = PolicyMap.createWsdlMessageScopeKey(
+                        serviceName, portName, operationName);
+                Policy inputMessagePolicy = wsPolicyMap.getInputMessageEffectivePolicy(messageKey);
+                setPolicyCredentials(inputMessagePolicy);
+                Policy outputMessagePolicy = wsPolicyMap.getOutputMessageEffectivePolicy(messageKey);
+                setPolicyCredentials(outputMessagePolicy);
+                for (WSDLFault fault : operation.getOperation().getFaults()) {
+                    PolicyMapKey faultKey = PolicyMap.createWsdlFaultMessageScopeKey(
+                            serviceName, portName, operationName,
+                            new QName(operationName.getNamespaceURI(), fault.getName()));
+                    Policy faultPolicy = wsPolicyMap.getFaultMessageEffectivePolicy(faultKey);
+                    setPolicyCredentials(faultPolicy);
+                }
             }
 
             if (endpointPolicy == null) {


### PR DESCRIPTION
This change includes the policies specified on message (input/output/fault) level when trying to identify the "policy credentials" and is a potential fix for #269.
I did not investigate further whether it actually makes sense to limit the policy credentials search to the parts belonging to the WSLPort given in the tubeConfig, but followed the approach used in the surrounding code. Iterating over the whole policyMap instead could be faster.