### PR TITLE
Respect potential message-level algorithm suite in server

### DIFF
--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityServerTube.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityServerTube.java
@@ -567,7 +567,8 @@ public class SecurityServerTube extends SecurityTubeBase {
             }
             // set the policy, issued-token-map, and extraneous properties
             //ctx.setIssuedTokenContextMap(issuedTokenContextMap);
-            if (isSCMessage) {
+            if (isSCMessage || policy.getAlgorithmSuite() != null) {
+                //override the binding level suite
                 ctx.setAlgorithmSuite(policy.getAlgorithmSuite());
             } else {
                 ctx.setAlgorithmSuite(getAlgoSuite(getBindingAlgorithmSuite(packet)));


### PR DESCRIPTION
Currently, the SecurityServerTube does not consider a potential message level algorithm suite (in contrast to the SecurityTubeBase used for the client logic). This way, the messages send as client use the correct algorithm suite, but the server seems to fall back to defaults.
This PR copies a tiny bit of logic from the SecurityTubeBase method implementation to the overwritten one in SecurityServerTube to fix this.