### PR TITLE
Updates to pass CVE checks

### DIFF
--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -49,7 +49,7 @@
 
         <hk2.version>3.0.3</hk2.version>
         <grizzly.version>4.0.0</grizzly.version>
-        <tomcat.coyote.version>10.1.4</tomcat.coyote.version>
+        <tomcat.coyote.version>10.1.13</tomcat.coyote.version>
         <graal.sdk.version>22.3.0</graal.sdk.version>
 
         <junit.version>4.13.2</junit.version>

--- a/wsit/pom.xml
+++ b/wsit/pom.xml
@@ -238,7 +238,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>8.0.1</version>
+                    <version>8.4.0</version>
                     <configuration>
                         <failBuildOnCVSS>7</failBuildOnCVSS>
                         <skipProvidedScope>true</skipProvidedScope>


### PR DESCRIPTION
CVE-2023-24998
CVE-2023-41080
CVE-2023-28708

See also: https://github.com/jeremylong/DependencyCheck/issues/5287 - we use the OWASP plugin which had the same issue, it seems resolved with the latest version.
