### PR TITLE
Fix wrapping ServletContext into WSSServletContextFacade

### DIFF
--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/util/ServletContextUtil.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/util/ServletContextUtil.java
@@ -50,11 +50,16 @@ public class ServletContextUtil {
         if (context == null) {
             return null;
         }
+
+        if(context instanceof WSSServletContextFacade) {
+            return (WSSServletContextFacade) context;
+        }
+
         Class<?> servletContextClass = findServletContextClass();
         if (servletContextClass == null) {
             return null;
         }
-        if (servletContextClass.isInstance(servletContextClass)) {
+        if (servletContextClass.isInstance(context)) {
             return new WSSServletContextFacade(context);
         }
         return null;


### PR DESCRIPTION
After upgrading Metro from 2.4.3 to 4.0.4, we run into the issue that our context-specific resources where not loaded anymore (e.g. the service `com.sun.xml.xwss.RealmAuthenticator`). It seems that the issue is how the context gets wrapped into a `WSSServletContextFacade`. This PR introduces the needed changes to make sure that the context gets wrapped correctly into a `WSSServletContextFacade`.