### PR TITLE
Skip overriding algorithm suite in case there is no fault policy

### DIFF
--- a/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityServerTube.java
+++ b/wsit/ws-sx/wssx-impl/src/main/java/com/sun/xml/wss/jaxws/impl/SecurityServerTube.java
@@ -567,7 +567,7 @@ public class SecurityServerTube extends SecurityTubeBase {
             }
             // set the policy, issued-token-map, and extraneous properties
             //ctx.setIssuedTokenContextMap(issuedTokenContextMap);
-            if (isSCMessage || policy.getAlgorithmSuite() != null) {
+            if (policy != null && (isSCMessage || policy.getAlgorithmSuite() != null)) {
                 //override the binding level suite
                 ctx.setAlgorithmSuite(policy.getAlgorithmSuite());
             } else {


### PR DESCRIPTION
This is another fix (see #461) needed to successfully upgrade from Metro 2.4.3 to 4.0.4. We are using a custom RealmAuthenticationAdapter and when this one throws a `XWSSecurityException`, we get a nullpointer while writing the response as the policy is null.