### PR TITLE
WS-AT recovery is enabled but WS-AT is not ready for runtime #707

### DIFF
--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/boms/bom-gf/pom.xml
+++ b/wsit/boms/bom-gf/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/boms/bom/pom.xml
+++ b/wsit/boms/bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/metro-standalone/pom.xml
+++ b/wsit/bundles/metro-standalone/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/pom.xml
+++ b/wsit/bundles/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/webservices-api-osgi/pom.xml
+++ b/wsit/bundles/webservices-api-osgi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/webservices-api/pom.xml
+++ b/wsit/bundles/webservices-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/webservices-extra-jdk-packages/pom.xml
+++ b/wsit/bundles/webservices-extra-jdk-packages/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/webservices-extra/pom.xml
+++ b/wsit/bundles/webservices-extra/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/webservices-tools/pom.xml
+++ b/wsit/bundles/webservices-tools/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/wsit-api/pom.xml
+++ b/wsit/bundles/wsit-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/bundles/wsit-impl/pom.xml
+++ b/wsit/bundles/wsit-impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/docs/getting-started/pom.xml
+++ b/wsit/docs/getting-started/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/docs/guide/pom.xml
+++ b/wsit/docs/guide/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/docs/pom.xml
+++ b/wsit/docs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/metro-cm/metro-cm-api/pom.xml
+++ b/wsit/metro-cm/metro-cm-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/metro-cm/metro-cm-impl/pom.xml
+++ b/wsit/metro-cm/metro-cm-impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/metro-cm/pom.xml
+++ b/wsit/metro-cm/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/metro-commons/pom.xml
+++ b/wsit/metro-commons/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/metro-config/metro-config-api/pom.xml
+++ b/wsit/metro-config/metro-config-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/metro-config/metro-config-impl/pom.xml
+++ b/wsit/metro-config/metro-config-impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/metro-config/pom.xml
+++ b/wsit/metro-config/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/metro-runtime/metro-runtime-api/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/metro-runtime/metro-runtime-impl/pom.xml
+++ b/wsit/metro-runtime/metro-runtime-impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/metro-runtime/pom.xml
+++ b/wsit/metro-runtime/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/pom.xml
+++ b/wsit/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/soaptcp/pom.xml
+++ b/wsit/soaptcp/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/soaptcp/soaptcp-api/pom.xml
+++ b/wsit/soaptcp/soaptcp-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/soaptcp/soaptcp-impl/pom.xml
+++ b/wsit/soaptcp/soaptcp-impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/tests/e2e/pom.xml
+++ b/wsit/tests/e2e/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/tests/osgi-test/pom.xml
+++ b/wsit/tests/osgi-test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/tests/pom.xml
+++ b/wsit/tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-mex/pom.xml
+++ b/wsit/ws-mex/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-rx/pom.xml
+++ b/wsit/ws-rx/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-rx/wsmc-api/pom.xml
+++ b/wsit/ws-rx/wsmc-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-rx/wsmc-impl/pom.xml
+++ b/wsit/ws-rx/wsmc-impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-rx/wsrm-api/pom.xml
+++ b/wsit/ws-rx/wsrm-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-rx/wsrm-impl/pom.xml
+++ b/wsit/ws-rx/wsrm-impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-rx/wsrx-commons/pom.xml
+++ b/wsit/ws-rx/wsrx-commons/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-rx/wsrx-testing/pom.xml
+++ b/wsit/ws-rx/wsrx-testing/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-sx/pom.xml
+++ b/wsit/ws-sx/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-sx/wssx-api/pom.xml
+++ b/wsit/ws-sx/wssx-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-sx/wssx-impl/pom.xml
+++ b/wsit/ws-sx/wssx-impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-tx/pom.xml
+++ b/wsit/ws-tx/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-tx/wstx-api/pom.xml
+++ b/wsit/ws-tx/wstx-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-tx/wstx-api/src/main/java/com/sun/xml/ws/tx/dev/WSATRuntimeConfig.java
+++ b/wsit/ws-tx/wstx-api/src/main/java/com/sun/xml/ws/tx/dev/WSATRuntimeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -86,7 +86,7 @@ public final class WSATRuntimeConfig {
     }
     private static WSATRuntimeConfig instance;
     private static boolean isWsatRecoveryEnabled = Boolean.parseBoolean(System.getProperty("wsat.recovery.enabled", "true"));
-    private static TxlogLocationProvider txLogLocationProvider;
+    private static TxlogLocationProvider txLogLocationProvider = () -> System.getProperty("java.io.tmpdir") + "/wsat";
     private static boolean isWsatSslEnabled = Boolean.getBoolean("wsat.ssl.enabled");
     private static boolean isRollbackOnFailedPrepare = Boolean.parseBoolean(System.getProperty("wsat.rollback.on.failed.prepare", "true"));
     private static String domainName = "domain1";

--- a/wsit/ws-tx/wstx-impl/pom.xml
+++ b/wsit/ws-tx/wstx-impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/ws-tx/wstx-impl/src/main/java/com/sun/xml/ws/tx/at/common/TransactionImportManager.java
+++ b/wsit/ws-tx/wstx-impl/src/main/java/com/sun/xml/ws/tx/at/common/TransactionImportManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -217,7 +217,7 @@ public class TransactionImportManager implements TransactionImportWrapper {
         return getTxLogLocation.invoke(javaeeTM);
     }
 
-    public static void registerRecoveryResourceHandler(XAResource xaResource) {
+    public void registerRecoveryResourceHandler(XAResource xaResource) {
         registerRecoveryResourceHandler.invoke(javaeeTM, xaResource);
     }
 }

--- a/wsit/ws-tx/wstx-impl/src/main/java/com/sun/xml/ws/tx/at/internal/WSATGatewayRM.java
+++ b/wsit/ws-tx/wstx-impl/src/main/java/com/sun/xml/ws/tx/at/internal/WSATGatewayRM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -108,7 +108,7 @@ public class WSATGatewayRM implements XAResource, WSATRuntimeConfig.RecoveryEven
 
     private static boolean setupRecovery() {
         if (!WSATRuntimeConfig.getInstance().isWSATRecoveryEnabled()) return true;
-        TransactionImportManager.registerRecoveryResourceHandler(singleton);
+        TransactionImportManager.getInstance().registerRecoveryResourceHandler(singleton);
         WSATRuntimeConfig.getInstance().setWSATRecoveryEventListener(singleton);
         setTxLogDirs();
         try {
@@ -572,7 +572,7 @@ public class WSATGatewayRM implements XAResource, WSATRuntimeConfig.RecoveryEven
         if (!delegated) {
             return;
         }
-        TransactionImportManager.registerRecoveryResourceHandler(
+        TransactionImportManager.getInstance().registerRecoveryResourceHandler(
                 new WSATGatewayRMPeerRecoveryDelegate(instance));
     }
 

--- a/wsit/ws-tx/wstx-impl/src/main/java/com/sun/xml/ws/tx/at/internal/WSATGatewayRM.java
+++ b/wsit/ws-tx/wstx-impl/src/main/java/com/sun/xml/ws/tx/at/internal/WSATGatewayRM.java
@@ -378,6 +378,10 @@ public class WSATGatewayRM implements XAResource, WSATRuntimeConfig.RecoveryEven
             singleton.recoverPendingBranches(delegatedtxlogdirOutbound, delegatedtxlogdirInbound);
         } else if(!isReadyForRuntime){
             try {
+                // txlogdir is null when wsat.recovery.enabled=false. We need to initialize it
+                if (txlogdir == null) {
+                    setTxLogDirs();
+                }
                 initStore();
             } catch (Exception e) {
                 XAException xaEx = new XAException("WSATGatewayRM recover call failed due to StoreException:" + e);
@@ -400,7 +404,7 @@ public class WSATGatewayRM implements XAResource, WSATRuntimeConfig.RecoveryEven
         return new Xid[0];
     }
 
-    static void setTxLogDirs() {
+    private synchronized static void setTxLogDirs() {
         txlogdir = getTxLogDir();
          debug("txlogdir is" + txlogdir);
          String wstxlogdir = txlogdir;

--- a/wsit/ws-tx/wstx-services/pom.xml
+++ b/wsit/ws-tx/wstx-services/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/wsit/xmlfilter/pom.xml
+++ b/wsit/xmlfilter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at


### PR DESCRIPTION
https://github.com/eclipse-ee4j/metro-jax-ws/issues/707

`TransactionImportManager#registerRecoveryResourceHandler` is null, and because of this, WSATGatewayRM cannot be instanced correctly when invoked `WSATGatewayRM#create`

![image](https://github.com/user-attachments/assets/92c2f711-516c-408c-bbfa-d68eb9c3b22c)

It was introduced here:
https://github.com/eclipse-ee4j/metro-wsit/commit/f981ee9567b16f1f4cb0cf87d48aa96de61c4bb5

I removed the static to avoid somebody refactor the code trying to fix warnings.
