### PR TITLE
Fixed most of excluded tests in metro-config-impl

### DIFF
--- a/wsit/metro-config/metro-config-impl/pom.xml
+++ b/wsit/metro-config/metro-config-impl/pom.xml
@@ -27,28 +27,6 @@
     <packaging>jar</packaging>
     <name>Metro Configuration Implementation</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <!-- TODO: Remove exlusion of tests once adapted to maven project structure -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>
-                            com/sun/xml/ws/policy/parser/PolicyConfigParserTest.java
-                        </exclude>
-                        <exclude>
-                            com/sun/xml/ws/policy/parser/PolicyWSDLParserExtensionTest.java
-                        </exclude>
-                    </excludes>
-                    <!-- TODO: missing export in jaxws-ri M4, fixed in later versions -->
-                    <argLine>--add-exports com.sun.xml.ws.rt/com.sun.xml.ws.runtime.config=org.glassfish.metro.config.impl</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -109,5 +87,39 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>policy/parser/*.wsdl</include>
+                </includes>
+            </testResource>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+                <excludes>
+                    <exclude>policy/parser/*.wsdl</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <srcDir>${project.build.testOutputDirectory}</srcDir>
+                        <manifestDir>${project.build.testOutputDirectory}/META-INF</manifestDir>
+                        <workDir>${project.build.directory}/workdir</workDir>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/wsit/metro-config/metro-config-impl/src/test/java/com/sun/xml/ws/policy/parser/PolicyConfigParserTest.java
+++ b/wsit/metro-config/metro-config-impl/src/test/java/com/sun/xml/ws/policy/parser/PolicyConfigParserTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,27 +19,30 @@ import com.sun.xml.ws.policy.PolicyMap;
 import com.sun.xml.ws.policy.PolicyMapKey;
 import com.sun.xml.ws.policy.privateutil.PolicyUtils;
 import com.sun.xml.ws.policy.testutils.PolicyResourceLoader;
-import static com.sun.xml.ws.policy.testutils.PolicyResourceLoader.getResourceUrl;
-import static com.sun.xml.ws.policy.testutils.PolicyResourceLoader.loadPolicy;
+
+import jakarta.xml.ws.WebServiceException;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import javax.xml.namespace.QName;
-import jakarta.xml.ws.WebServiceException;
+
 import junit.framework.TestCase;
+
+import static com.sun.xml.ws.policy.testutils.PolicyResourceLoader.getResourceUrl;
+import static com.sun.xml.ws.policy.testutils.PolicyResourceLoader.loadPolicy;
 
 /**
  * @author Fabian Ritzmann
  */
 public class PolicyConfigParserTest extends TestCase {
-    private static final String TEST_FILE_PATH = "test/unit/data/policy/config/wsit.xml";
-    private static final String CONFIG_FILE_PATH = "test/unit/data/META-INF";
-    private static final String CLASSPATH_CONFIG_FILE_PATH = "test/unit/data";
-    private static final String CONFIG_FILE_NAME = "wsit-test.xml";
+    private static final Path SRC_DIR = new File(System.getProperty("srcDir")).toPath();
+    private static final Path MANIFEST_DIR = new File(System.getProperty("manifestDir")).toPath();
+
+    private static final Path TEST_FILE_PATH = SRC_DIR.resolve(Path.of("policy", "config", "wsit.xml"));
     private static final String CLIENT_CONFIG_FILE_NAME = "wsit-client.xml";
 
     public PolicyConfigParserTest(String testName) {
@@ -72,29 +76,30 @@ public class PolicyConfigParserTest extends TestCase {
         }
     }
 
-    public void testParseContainerNullWithConfig() throws Exception {
-        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, CONFIG_FILE_PATH, CONFIG_FILE_NAME, "test", null);
-        testLoadedMap(map);
-    }
-
-    public void testParseContainerWithoutContext() throws Exception {
-        Container container = new MockContainer(null);
-        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, CONFIG_FILE_PATH, CONFIG_FILE_NAME, "test", container);
-        testLoadedMap(map);
-    }
+      // Throws exception, "{http://schemas.sun.com/2006/03/wss/server}KeyStore" is not available
+//    public void testParseContainerNullWithConfig() throws Exception {
+//        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, MANIFEST_DIR.resolve(CONFIG_FILE_NAME), "test", null);
+//        testLoadedMap(map);
+//    }
+//
+//    public void testParseContainerWithoutContext() throws Exception {
+//        Container container = new MockContainer(null);
+//        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, MANIFEST_DIR.resolve(CONFIG_FILE_NAME), "test", container);
+//        testLoadedMap(map);
+//    }
 
     public void testParseContainerWithContext() {
         // TODO Need MockServletContext
     }
 
     public void testWsitXmlNotLoadedContainerNullWithConfig() throws Exception {
-        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, CONFIG_FILE_PATH, "wsit.xml", "test", null);
+        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, MANIFEST_DIR.resolve("wsit.xml"), "test", null);
         assertNull(map);
     }
 
     public void testWsitXmlNotLoadedContainerWithoutContext() throws Exception {
         Container container = new MockContainer(null);
-        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, CONFIG_FILE_PATH, "wsit.xml", "test", container);
+        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, MANIFEST_DIR.resolve("wsit.xml"), "test", container);
         assertNull(map);
     }
 
@@ -102,30 +107,31 @@ public class PolicyConfigParserTest extends TestCase {
         // TODO Need MockServletContext
     }
 
-    public void testParseClientWithoutContextWithoutConfig() throws Exception {
-        PolicyMap result = PolicyConfigParser.parse(PolicyConstants.CLIENT_CONFIGURATION_IDENTIFIER, null);
-        assertNull(result);
-    }
+    // Throws exception, tries to load file which we did not prepare.
+//    public void testParseClientWithoutContextWithoutConfig() throws Exception {
+//        PolicyMap result = PolicyConfigParser.parse(PolicyConstants.CLIENT_CONFIGURATION_IDENTIFIER, null);
+//        assertNull(result);
+//    }
 
     public void testParseClientMetainfContainerNullWithConfig() throws Exception {
-        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, CONFIG_FILE_PATH, CLIENT_CONFIG_FILE_NAME, PolicyConstants.CLIENT_CONFIGURATION_IDENTIFIER, null);
+        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, MANIFEST_DIR.resolve(CLIENT_CONFIG_FILE_NAME), PolicyConstants.CLIENT_CONFIGURATION_IDENTIFIER, null);
         testLoadedMap(map);
     }
 
     public void testParseClientMetainfWithoutContext() throws Exception {
         Container container = new MockContainer(null);
-        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, CONFIG_FILE_PATH, CLIENT_CONFIG_FILE_NAME, PolicyConstants.CLIENT_CONFIGURATION_IDENTIFIER, container);
+        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, MANIFEST_DIR.resolve(CLIENT_CONFIG_FILE_NAME), PolicyConstants.CLIENT_CONFIGURATION_IDENTIFIER, container);
         testLoadedMap(map);
     }
 
     public void testParseClientClasspathContainerNullWithConfig() throws Exception {
-        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, CLASSPATH_CONFIG_FILE_PATH, CLIENT_CONFIG_FILE_NAME, PolicyConstants.CLIENT_CONFIGURATION_IDENTIFIER, null);
+        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, SRC_DIR.resolve(CLIENT_CONFIG_FILE_NAME), PolicyConstants.CLIENT_CONFIGURATION_IDENTIFIER, null);
         testLoadedMap(map);
     }
 
     public void testParseClientClasspathWithoutContext() throws Exception {
         Container container = new MockContainer(null);
-        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, CLASSPATH_CONFIG_FILE_PATH, CLIENT_CONFIG_FILE_NAME, PolicyConstants.CLIENT_CONFIGURATION_IDENTIFIER, container);
+        PolicyMap map = prepareTestFileAndLoadPolicyMap(TEST_FILE_PATH, SRC_DIR.resolve(CLIENT_CONFIG_FILE_NAME), PolicyConstants.CLIENT_CONFIGURATION_IDENTIFIER, container);
         testLoadedMap(map);
     }
 
@@ -313,53 +319,15 @@ public class PolicyConfigParserTest extends TestCase {
         return PolicyConfigParser.parse(url, true);
     }
 
-    /**
-     * Copy a file
-     *
-     * @param sourceName source file name
-     * @param destPath destination path
-     * @param destName destination file name
-     * @throws IOException Thrown if copy failed
-     */
-    private static void copyFile(String sourceName, String destPath, String destName) throws IOException {
-        FileChannel source = null;
-        FileChannel dest = null;
+    private PolicyMap prepareTestFileAndLoadPolicyMap(Path srcFile, Path target, String cfgFileId, Container container) throws PolicyException, IOException {
         try {
-            File destDir = new File(destPath);
-            destDir.mkdir();
-
-            // Create channel on the source
-            source = new FileInputStream(sourceName).getChannel();
-
-            // Create channel on the destination
-            dest = new FileOutputStream(destPath + File.separatorChar + destName).getChannel();
-
-            // Copy file contents from source to destination
-            dest.transferFrom(source, 0, source.size());
-
-        } finally {
-            // Close the channels
-            if (source != null) {
-                try {
-                    source.close();
-                } catch (IOException e) {
-                }
+            if (!Files.isDirectory(target.getParent())) {
+                Files.createDirectories(target.getParent());
             }
-            if (dest != null) {
-                dest.close();
-            }
-        }
-    }
-
-    private PolicyMap prepareTestFileAndLoadPolicyMap(String sourceName, String destPath, String destName, String cfgFileId, Container container) throws PolicyException, IOException {
-        PolicyMap result;
-        try {
-            copyFile(sourceName, destPath, destName);
-            result = PolicyConfigParser.parse(cfgFileId, container);
-            return result;
+            Files.copy(srcFile, target);
+            return PolicyConfigParser.parse(cfgFileId, container);
         } finally {
-            File wsitxml = new File(destPath + File.separatorChar + destName);
-            wsitxml.delete();
+            Files.deleteIfExists(target);
         }
     }
 

--- a/wsit/metro-config/metro-config-impl/src/test/java/com/sun/xml/ws/policy/parser/PolicyWSDLParserExtensionTest.java
+++ b/wsit/metro-config/metro-config-impl/src/test/java/com/sun/xml/ws/policy/parser/PolicyWSDLParserExtensionTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -10,9 +11,6 @@
 
 package com.sun.xml.ws.policy.parser;
 
-import com.sun.xml.ws.policy.parser.PolicyConfigParser;
-import static com.sun.xml.ws.policy.testutils.PolicyResourceLoader.getPolicyMap;
-
 import com.sun.xml.ws.api.model.wsdl.WSDLModel;
 import com.sun.xml.ws.policy.AssertionSet;
 import com.sun.xml.ws.policy.Policy;
@@ -21,12 +19,16 @@ import com.sun.xml.ws.policy.PolicyMap;
 import com.sun.xml.ws.policy.PolicyMapKey;
 import com.sun.xml.ws.policy.testutils.PolicyResourceLoader;
 
-import javax.xml.namespace.QName;
 import jakarta.xml.ws.WebServiceException;
+
 import java.net.URL;
 import java.util.Collection;
-import javax.xml.stream.XMLInputFactory;
+
+import javax.xml.namespace.QName;
+
 import junit.framework.TestCase;
+
+import static com.sun.xml.ws.policy.testutils.PolicyResourceLoader.getPolicyMap;
 
 /**
  *
@@ -34,7 +36,6 @@ import junit.framework.TestCase;
  * @author Fabian Ritzmann
  */
 public class PolicyWSDLParserExtensionTest extends TestCase{
-    private static final XMLInputFactory XML_INPUT_FACTORY = XMLInputFactory.newInstance();
 
     public PolicyWSDLParserExtensionTest(String testName) {
         super(testName);
@@ -706,39 +707,41 @@ public class PolicyWSDLParserExtensionTest extends TestCase{
 
     }
 
-    public void testNamespaceImport() throws PolicyException {
-        PolicyMap map = getPolicyMap("parser/testNamespaceImport.wsdl", false);
-
-        Policy policy = map.getEndpointEffectivePolicy(PolicyMap.createWsdlEndpointScopeKey(
-                new QName("STSUserAuth_svc_app", "casaService1"),
-                new QName("STSUserAuth_svc_app", "SecuredEchoPort")));
-        assertEquals("casaBinding1Policy", policy.getId());
-
-        policy = map.getOperationEffectivePolicy(PolicyMap.createWsdlOperationScopeKey(
-                new QName("STSUserAuth_svc_app", "casaService1"),
-                new QName("STSUserAuth_svc_app", "SecuredEchoPort"),
-                new QName("STSUserAuth_svc_app", "EchoServiceOperation")));
-        assertEquals("casaBinding1_operation_Policy", policy.getId());
-
-        policy = map.getInputMessageEffectivePolicy(PolicyMap.createWsdlMessageScopeKey(
-                new QName("STSUserAuth_svc_app", "casaService1"),
-                new QName("STSUserAuth_svc_app", "SecuredEchoPort"),
-                new QName("STSUserAuth_svc_app", "EchoServiceOperation")));
-        assertEquals("casaBinding1_input1_Policy", policy.getId());
-
-        policy = map.getOutputMessageEffectivePolicy(PolicyMap.createWsdlMessageScopeKey(
-                new QName("STSUserAuth_svc_app", "casaService1"),
-                new QName("STSUserAuth_svc_app", "SecuredEchoPort"),
-                new QName("STSUserAuth_svc_app", "EchoServiceOperation")));
-        assertEquals("casaBinding1_output1_Policy", policy.getId());
-
-        policy = map.getFaultMessageEffectivePolicy(PolicyMap.createWsdlFaultMessageScopeKey(
-                new QName("STSUserAuth_svc_app", "casaService1"),
-                new QName("STSUserAuth_svc_app", "SecuredEchoPort"),
-                new QName("STSUserAuth_svc_app", "EchoServiceOperation"),
-                new QName("STSUserAuth_svc_app", "fault1")));
-        assertEquals("casaBinding1_fault1_Policy", policy.getId());
-    }
+      // FIXME: For some reason doesn't pass validation:
+      // WSP1015: Server side assertion validation failed for "{http://www.w3.org/2006/05/addressing/wsdl}UsingAddressing" assertion. Assertion was evaluated as "UNKNOWN".
+//    public void testNamespaceImport() throws PolicyException {
+//        PolicyMap map = getPolicyMap("parser/testNamespaceImport.wsdl", false);
+//
+//        Policy policy = map.getEndpointEffectivePolicy(PolicyMap.createWsdlEndpointScopeKey(
+//                new QName("STSUserAuth_svc_app", "casaService1"),
+//                new QName("STSUserAuth_svc_app", "SecuredEchoPort")));
+//        assertEquals("casaBinding1Policy", policy.getId());
+//
+//        policy = map.getOperationEffectivePolicy(PolicyMap.createWsdlOperationScopeKey(
+//                new QName("STSUserAuth_svc_app", "casaService1"),
+//                new QName("STSUserAuth_svc_app", "SecuredEchoPort"),
+//                new QName("STSUserAuth_svc_app", "EchoServiceOperation")));
+//        assertEquals("casaBinding1_operation_Policy", policy.getId());
+//
+//        policy = map.getInputMessageEffectivePolicy(PolicyMap.createWsdlMessageScopeKey(
+//                new QName("STSUserAuth_svc_app", "casaService1"),
+//                new QName("STSUserAuth_svc_app", "SecuredEchoPort"),
+//                new QName("STSUserAuth_svc_app", "EchoServiceOperation")));
+//        assertEquals("casaBinding1_input1_Policy", policy.getId());
+//
+//        policy = map.getOutputMessageEffectivePolicy(PolicyMap.createWsdlMessageScopeKey(
+//                new QName("STSUserAuth_svc_app", "casaService1"),
+//                new QName("STSUserAuth_svc_app", "SecuredEchoPort"),
+//                new QName("STSUserAuth_svc_app", "EchoServiceOperation")));
+//        assertEquals("casaBinding1_output1_Policy", policy.getId());
+//
+//        policy = map.getFaultMessageEffectivePolicy(PolicyMap.createWsdlFaultMessageScopeKey(
+//                new QName("STSUserAuth_svc_app", "casaService1"),
+//                new QName("STSUserAuth_svc_app", "SecuredEchoPort"),
+//                new QName("STSUserAuth_svc_app", "EchoServiceOperation"),
+//                new QName("STSUserAuth_svc_app", "fault1")));
+//        assertEquals("casaBinding1_fault1_Policy", policy.getId());
+//    }
 
     public void testPolicyMapToString() throws Exception {
         PolicyMap policyMap = getPolicyMap("bug_reproduction/simple.wsdl");

--- a/wsit/metro-config/metro-config-impl/src/test/java/com/sun/xml/ws/policy/testutils/PolicyResourceLoader.java
+++ b/wsit/metro-config/metro-config-impl/src/test/java/com/sun/xml/ws/policy/testutils/PolicyResourceLoader.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -10,20 +11,23 @@
 
 package com.sun.xml.ws.policy.testutils;
 
-import com.sun.xml.ws.api.policy.ModelTranslator;
 import com.sun.xml.stream.buffer.XMLStreamBuffer;
 import com.sun.xml.ws.api.model.wsdl.WSDLModel;
+import com.sun.xml.ws.api.policy.ModelTranslator;
 import com.sun.xml.ws.api.policy.ModelUnmarshaller;
 import com.sun.xml.ws.policy.Policy;
 import com.sun.xml.ws.policy.PolicyException;
 import com.sun.xml.ws.policy.PolicyMap;
 import com.sun.xml.ws.policy.sourcemodel.PolicySourceModel;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.MalformedURLException;
 import java.net.URL;
+
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 
@@ -81,7 +85,12 @@ public final class PolicyResourceLoader {
     }
 
     public static URL getResourceUrl(String resourceName) {
-        return Thread.currentThread().getContextClassLoader().getResource(POLICY_UNIT_TEST_RESOURCE_ROOT + resourceName);
+        File srcDir = new File(System.getProperty("srcDir"));
+        try {
+            return new File(srcDir, POLICY_UNIT_TEST_RESOURCE_ROOT + resourceName).toURI().toURL();
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     public static Policy translateModel(PolicySourceModel model) throws PolicyException {
@@ -118,7 +127,7 @@ public final class PolicyResourceLoader {
         try {
             return com.sun.xml.ws.policy.parser.PolicyResourceLoader.getWsdlModel(resourceUrl, isClient);
         } catch (XMLStreamException | SAXException | IOException ex) {
-            throw new PolicyException("Failed to parse document", ex);
+            throw new PolicyException("Failed to parse document " + resourceUrl, ex);
         }
     }
 

--- a/wsit/metro-config/metro-config-impl/src/test/resources/policy/parser/testRuntimeWSExtExternalBindingOpFault.wsdl
+++ b/wsit/metro-config/metro-config-impl/src/test/resources/policy/parser/testRuntimeWSExtExternalBindingOpFault.wsdl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -51,7 +51,7 @@
         <soap:body use="literal"/>
       </wsdl:output>
       <wsdl:fault name="Fault">
-        <wsp:PolicyReference URI="file:test/unit/data/policy/parser/testWsdlParserBasics.wsdl#DummyPolicy"/>
+        <wsp:PolicyReference URI="file:${project.build.testOutputDirectory}/policy/parser/testWsdlParserBasics.wsdl#DummyPolicy"/>
         <soap:body use="literal"/>
       </wsdl:fault>
     </wsdl:operation>

--- a/wsit/metro-config/metro-config-impl/src/test/resources/policy/parser/testRuntimeWSExtExternalFromAnonBindingOpFault.wsdl
+++ b/wsit/metro-config/metro-config-impl/src/test/resources/policy/parser/testRuntimeWSExtExternalFromAnonBindingOpFault.wsdl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
+    Copyright (c) 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -52,7 +52,7 @@
       </wsdl:output>
       <wsdl:fault name="Fault">
         <wsp:Policy>
-        	<wsp:PolicyReference URI="file:test/unit/data/policy/parser/testWsdlParserBasics.wsdl#DummyPolicy"/>
+          <wsp:PolicyReference URI="file:${project.build.testOutputDirectory}/policy/parser/testWsdlParserBasics.wsdl#DummyPolicy"/>
         </wsp:Policy>
         <soap:body use="literal"/>
       </wsdl:fault>


### PR DESCRIPTION
Should be rebased and merged after #482 and #481 

These tests were disabled for a very long time, so I fixed them.
Few were left commented out, because they really fail, probably trying to use unsupported namespace.