### PR TITLE
Removed unused obsoleted dependency: net.java.dev.stax-utils

### DIFF
--- a/wsit/boms/bom-ext/pom.xml
+++ b/wsit/boms/bom-ext/pom.xml
@@ -21,7 +21,6 @@
         <version>4.0.6-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.glassfish.metro</groupId>
     <artifactId>metro-bom-ext</artifactId>
     <packaging>pom</packaging>
     <name>Metro Web Services Stack Dependency POM for Metro-CS</name>
@@ -39,7 +38,6 @@
         <santuario.version>4.0.2</santuario.version>
         <commons-codec.version>1.17.0</commons-codec.version>
 
-        <stax-utils.version>20070216</stax-utils.version>
 
         <hk2.version>3.1.0</hk2.version>
         <graal.sdk.version>22.3.3</graal.sdk.version>
@@ -154,17 +152,6 @@
                 <optional>true</optional>
             </dependency>
 
-            <dependency>
-                <groupId>net.java.dev.stax-utils</groupId>
-                <artifactId>stax-utils</artifactId>
-                <version>${stax-utils.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.bea.xml</groupId>
-                        <artifactId>jsr173-ri</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-coyote</artifactId>

--- a/wsit/bundles/webservices-osgi/pom.xml
+++ b/wsit/bundles/webservices-osgi/pom.xml
@@ -72,7 +72,7 @@
                         </goals>
                         <configuration>
                             <includeGroupIds>
-                                com.sun.xml.messaging.saaj,com.sun.xml.ws,org.glassfish.metro,com.sun.xml.stream.buffer,net.java.dev.stax-utils
+                                com.sun.xml.messaging.saaj,com.sun.xml.ws,org.glassfish.metro,com.sun.xml.stream.buffer
                             </includeGroupIds>
                             <excludeArtifactIds>jaxws-eclipselink-plugin,sdo-eclipselink-plugin</excludeArtifactIds>
                             <includeScope>provided</includeScope>
@@ -94,7 +94,7 @@
                         </goals>
                         <configuration>
                             <includeGroupIds>
-                                com.sun.xml.messaging.saaj,com.sun.xml.ws,org.glassfish.metro,com.sun.xml.stream.buffer,net.java.dev.stax-utils
+                                com.sun.xml.messaging.saaj,com.sun.xml.ws,org.glassfish.metro,com.sun.xml.stream.buffer
                             </includeGroupIds>
                             <excludeArtifactIds>jaxws-eclipselink-plugin,sdo-eclipselink-plugin</excludeArtifactIds>
                             <includeScope>provided</includeScope>
@@ -112,7 +112,7 @@
                         </goals>
                         <configuration>
                             <includeGroupIds>
-                                com.sun.xml.messaging.saaj,com.sun.xml.ws,org.glassfish.metro,com.sun.xml.stream.buffer,net.java.dev.stax-utils
+                                com.sun.xml.messaging.saaj,com.sun.xml.ws,org.glassfish.metro,com.sun.xml.stream.buffer
                             </includeGroupIds>
                             <excludeArtifactIds>jaxws-eclipselink-plugin,sdo-eclipselink-plugin</excludeArtifactIds>
                             <includeScope>provided</includeScope>
@@ -313,12 +313,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>net.java.dev.stax-utils</groupId>
-            <artifactId>stax-utils</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/wsit/bundles/webservices-rt/pom.xml
+++ b/wsit/bundles/webservices-rt/pom.xml
@@ -337,11 +337,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.java.dev.stax-utils</groupId>
-            <artifactId>stax-utils</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.gmbal</groupId>
             <artifactId>gmbal</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
It doesn't seem it is needed somehow, if it is, we should add some comments what triggers any usage of it.
I can try to rerun TCKs without it later after the release of GF8.